### PR TITLE
GlobalRenderResource 구현

### DIFF
--- a/RandEngine/RandEngine/Engine/Source/Runtime/Core/HAL/PlatformMemory.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Core/HAL/PlatformMemory.h
@@ -197,3 +197,8 @@ uint64 FPlatformMemory::GetAllocationCount()
     }
 }
 
+template <typename T>
+FORCEINLINE constexpr T Align(T Val, uint64 Alignment)
+{
+    return (T)(((uint64)Val + Alignment - 1) & ~(Alignment - 1));
+}

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleHelper.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleHelper.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Define.h"
 #include "Components/Material/Material.h"
+#include "Renderer/GlobalRenderResource.h"
 
 // UE5에서 일부 가져옴
 
@@ -459,18 +460,18 @@ struct FDynamicSpriteEmitterDataBase : public FDynamicEmitterDataBase
      *	@param	InVertexSize			Stride of these verts, only used for verification
      *	@param	InDynamicParameterVertexStride	Stride of the dynamic parameter
      */
-    //void BuildViewFillData(
-    //    const FParticleSystemSceneProxy* Proxy,
-    //    const FSceneView* InView,
-    //    int32 InVertexCount,
-    //    int32 InVertexSize,
-    //    int32 InDynamicParameterVertexSize,
-    //    FGlobalDynamicIndexBuffer& DynamicIndexBuffer,
-    //    FGlobalDynamicVertexBuffer& DynamicVertexBuffer,
-    //    FGlobalDynamicVertexBufferAllocation& DynamicVertexAllocation,
-    //    FGlobalDynamicIndexBufferAllocation& DynamicIndexAllocation,
-    //    FGlobalDynamicVertexBufferAllocation* DynamicParameterAllocation,
-    //    FAsyncBufferFillData& Data) const;
+    /*void BuildViewFillData(
+        const FParticleSystemSceneProxy* Proxy,
+        const FEditorViewportClient* InView,
+        int32 InVertexCount,
+        int32 InVertexSize,
+        int32 InDynamicParameterVertexSize,
+        FGlobalDynamicIndexBuffer& DynamicIndexBuffer,
+        FGlobalDynamicVertexBuffer& DynamicVertexBuffer,
+        FGlobalDynamicVertexBufferAllocation& DynamicVertexAllocation,
+        FGlobalDynamicIndexBufferAllocation& DynamicIndexAllocation,
+        FGlobalDynamicVertexBufferAllocation* DynamicParameterAllocation,
+        FAsyncBufferFillData& Data) const;*/
 
     const UMaterial* MaterialResource;
 

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleHelper.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleHelper.h
@@ -173,17 +173,17 @@ struct FAsyncBufferFillData
     /** View for this buffer fill task   */
     const FEditorViewportClient* View;
     /** Number of verts in VertexData   */
-    int32									VertexCount;
+    int32 VertexCount;
     /** Stride of verts, used only for error checking   */
-    int32									VertexSize;
+    int32 VertexSize;
     /** Pointer to vertex data   */
     void* VertexData;
     /** Number of indices in IndexData   */
-    int32									IndexCount;
+    int32 IndexCount;
     /** Pointer to index data   */
     void* IndexData;
     /** Number of triangles filled in   */
-    int32									OutTriangleCount;
+    int32 OutTriangleCount;
     /** Pointer to dynamic parameter data */
     void* DynamicParameterData;
 
@@ -440,17 +440,6 @@ struct FDynamicSpriteEmitterDataBase : public FDynamicEmitterDataBase
     {
     }
 
-
-    /**
-     *	Debug rendering
-     *
-     *	@param	Proxy		The primitive scene proxy for the emitter.
-     *	@param	PDI			The primitive draw interface to render with
-     *	@param	View		The scene view being rendered
-     *	@param	bCrosses	If true, render Crosses at particle position; false, render points
-     */
-    //virtual void RenderDebug(const FParticleSystemSceneProxy* Proxy, FPrimitiveDrawInterface* PDI, const FSceneView* View, bool bCrosses) const;
-
     /**
      *	Set up an buffer for async filling
      *
@@ -460,8 +449,7 @@ struct FDynamicSpriteEmitterDataBase : public FDynamicEmitterDataBase
      *	@param	InVertexSize			Stride of these verts, only used for verification
      *	@param	InDynamicParameterVertexStride	Stride of the dynamic parameter
      */
-    /*void BuildViewFillData(
-        const FParticleSystemSceneProxy* Proxy,
+    void BuildViewFillData(
         const FEditorViewportClient* InView,
         int32 InVertexCount,
         int32 InVertexSize,
@@ -471,7 +459,7 @@ struct FDynamicSpriteEmitterDataBase : public FDynamicEmitterDataBase
         FGlobalDynamicVertexBufferAllocation& DynamicVertexAllocation,
         FGlobalDynamicIndexBufferAllocation& DynamicIndexAllocation,
         FGlobalDynamicVertexBufferAllocation* DynamicParameterAllocation,
-        FAsyncBufferFillData& Data) const;*/
+        FAsyncBufferFillData& Data) const;
 
     const UMaterial* MaterialResource;
 

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/GlobalRenderResource.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/GlobalRenderResource.cpp
@@ -30,18 +30,19 @@ FGlobalDynamicVertexBuffer::FAllocation FGlobalDynamicVertexBuffer::Allocate(uin
 
 void FGlobalDynamicVertexBuffer::Commit()
 {
-    //// 1) 이번 프레임에 Allocate() 된 모든 버퍼를 Unmap()
-    //for (FDynamicVertexBuffer* VB : VertexBuffers)
-    //{
-    //    if (VB && VB->GPUBuffer && VB->MappedBuffer)
-    //    {
-    //        GD3DContext->Unmap(VB->GPUBuffer, 0);
-    //        VB->MappedBuffer = nullptr;
-    //    }
-    //}
+    ID3D11DeviceContext* D3DContext = GDynamicVertexBufferPool.Context;
+    // 1) 이번 프레임에 Allocate() 된 모든 버퍼를 Unmap()
+    for (FDynamicVertexBuffer* VB : VertexBuffers)
+    {
+        if (VB && VB->MappedBuffer)
+        {
+            // Context 는 전역이나 멤버로 보관하신 DeviceContext 를 사용하세요
+            VB->Unmap(D3DContext);
+        }
+    }
 
-    //// 2) 버퍼 목록 초기화 → 다음 프레임에 새로 Allocate 시작
-    //VertexBuffers.Reset();
+    // 2) 다음 프레임을 위해 할당 기록 리셋
+    VertexBuffers.Empty();
 }
 
 FGlobalDynamicIndexBuffer::FAllocation FGlobalDynamicIndexBuffer::Allocate(uint32 NumIndices, uint32 IndexStride)
@@ -80,5 +81,26 @@ FGlobalDynamicIndexBuffer::FAllocation FGlobalDynamicIndexBuffer::Allocate(uint3
 
 void FGlobalDynamicIndexBuffer::Commit()
 {
+    ID3D11DeviceContext* D3DContext = GDynamicIndexBufferPool.Context;
+
+    // 16비트 인덱스 버퍼 정리
+    for (FDynamicIndexBuffer* IB : IndexBuffers16)
+    {
+        if (IB && IB->MappedBuffer)
+        {
+            IB->Unmap(D3DContext);
+        }
+    }
+    IndexBuffers16.Empty();
+
+    // 32비트 인덱스 버퍼 정리
+    for (FDynamicIndexBuffer* IB : IndexBuffers32)
+    {
+        if (IB && IB->MappedBuffer)
+        {
+            IB->Unmap(D3DContext);
+        }
+    }
+    IndexBuffers32.Empty();
 }
 

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/GlobalRenderResource.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/GlobalRenderResource.cpp
@@ -1,0 +1,84 @@
+#include "GlobalRenderResource.h"
+#include "HAL/PlatformMemory.h"
+
+TDynamicBufferPool<FDynamicVertexBuffer> GDynamicVertexBufferPool;
+TDynamicBufferPool<FDynamicIndexBuffer> GDynamicIndexBufferPool;
+
+FGlobalDynamicVertexBuffer::FAllocation FGlobalDynamicVertexBuffer::Allocate(uint32 SizeInBytes)
+{
+    FAllocation Allocation;
+
+    if (VertexBuffers.IsEmpty() || VertexBuffers.Last()->AllocatedByteCount + SizeInBytes > VertexBuffers.Last()->BufferSize)
+    {
+        VertexBuffers.Emplace(GDynamicVertexBufferPool.Acquire(SizeInBytes, 0));
+    }
+
+    FDynamicVertexBuffer* VertexBuffer = VertexBuffers.Last();
+
+    if (!(VertexBuffer->AllocatedByteCount + SizeInBytes <= VertexBuffer->BufferSize))
+    {
+        UE_LOG(ELogLevel::Error, TEXT("Global vertex buffer allocation failed : BufferSize = % d AllocatedByteCount = % d SizeInBytes = % d"), VertexBuffer->BufferSize, VertexBuffer->AllocatedByteCount, SizeInBytes);
+        return Allocation;
+    }
+
+    Allocation.Buffer = VertexBuffer->MappedBuffer + VertexBuffer->AllocatedByteCount;
+    Allocation.VertexBuffer = VertexBuffer->GPUBuffer;
+    Allocation.VertexOffset = VertexBuffer->AllocatedByteCount;
+    VertexBuffer->AllocatedByteCount += Align(SizeInBytes, 16);
+    return Allocation;
+}
+
+void FGlobalDynamicVertexBuffer::Commit()
+{
+    //// 1) 이번 프레임에 Allocate() 된 모든 버퍼를 Unmap()
+    //for (FDynamicVertexBuffer* VB : VertexBuffers)
+    //{
+    //    if (VB && VB->GPUBuffer && VB->MappedBuffer)
+    //    {
+    //        GD3DContext->Unmap(VB->GPUBuffer, 0);
+    //        VB->MappedBuffer = nullptr;
+    //    }
+    //}
+
+    //// 2) 버퍼 목록 초기화 → 다음 프레임에 새로 Allocate 시작
+    //VertexBuffers.Reset();
+}
+
+FGlobalDynamicIndexBuffer::FAllocation FGlobalDynamicIndexBuffer::Allocate(uint32 NumIndices, uint32 IndexStride)
+{
+    FAllocation Allocation;
+
+    if (IndexStride != 2 && IndexStride != 4)
+    {
+        return Allocation;
+    }
+
+    const uint32 SizeInBytes = NumIndices * IndexStride;
+
+    TArray<FDynamicIndexBuffer*>& IndexBuffers = (IndexStride == 2)
+        ? IndexBuffers16
+        : IndexBuffers32;
+
+    if (IndexBuffers.IsEmpty() || IndexBuffers.Last()->AllocatedByteCount + SizeInBytes > IndexBuffers.Last()->BufferSize)
+    {
+        IndexBuffers.Emplace(GDynamicIndexBufferPool.Acquire(SizeInBytes, IndexStride));
+    }
+
+    FDynamicIndexBuffer* IndexBuffer = IndexBuffers.Last();
+
+    if (!(IndexBuffer->AllocatedByteCount + SizeInBytes <= IndexBuffer->BufferSize))
+    {
+        UE_LOG(ELogLevel::Error, TEXT("Global index buffer allocation failed : BufferSize = % d AllocatedByteCount = % d SizeInBytes = % d"), IndexBuffer->BufferSize, IndexBuffer->AllocatedByteCount, SizeInBytes);
+        return Allocation;
+    }
+    Allocation.Buffer = IndexBuffer->MappedBuffer + IndexBuffer->AllocatedByteCount;
+    Allocation.IndexBuffer = IndexBuffer->GPUBuffer;
+    Allocation.FirstIndex = IndexBuffer->AllocatedByteCount / IndexStride;
+    IndexBuffer->AllocatedByteCount += Align(SizeInBytes, 16);
+    return Allocation;
+}
+
+void FGlobalDynamicIndexBuffer::Commit()
+{
+}
+

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/GlobalRenderResource.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/GlobalRenderResource.h
@@ -1,0 +1,285 @@
+#pragma once
+#include "RenderResources.h"
+
+template <typename BufferType>
+class TDynamicBuffer;
+
+using FDynamicVertexBuffer = TDynamicBuffer<ID3D11Buffer>;
+using FDynamicIndexBuffer = TDynamicBuffer<ID3D11Buffer>;
+
+/**
+ * An individual dynamic vertex buffer.
+ */
+template <typename BufferType>
+class TDynamicBuffer final
+{
+public:
+    /** The aligned size of all dynamic vertex buffers. */
+    enum { ALIGNMENT = (1 << 16) }; // 64KB
+    /** Pointer to the vertex buffer mapped in main memory. */
+    uint8* MappedBuffer = nullptr;
+    /** The GPU buffer handle. */
+    BufferType* GPUBuffer = nullptr;
+    /** Size of the vertex buffer in bytes. */
+    uint32 BufferSize = 0;
+    /** Number of bytes currently allocated from the buffer. */
+    uint32 AllocatedByteCount = 0;
+    /** Stride of the buffer in bytes. */
+    uint32 Stride = 0;
+    /** Last render thread frame this resource was used in. */
+    uint64 LastUsedFrame = 0;
+
+    /** Default constructor. */
+    explicit TDynamicBuffer(uint32 InMinBufferSize, uint32 InStride)
+        : MappedBuffer(NULL)
+        , GPUBuffer(NULL)
+        , BufferSize(FMath::Max<uint32>(Align(InMinBufferSize, ALIGNMENT), ALIGNMENT))
+        , AllocatedByteCount(0)
+        , Stride(InStride)
+    {
+    }
+
+    void Init(ID3D11Device* Device, ID3D11DeviceContext* Context)
+    {
+        // (1) 기존 리소스 있으면 해제
+        if (GPUBuffer)
+        {
+            // unmap if still mapped
+            if (MappedBuffer)
+            {
+                Context->Unmap(GPUBuffer, 0);
+                MappedBuffer = nullptr;
+            }
+            GPUBuffer->Release();
+            GPUBuffer = nullptr;
+        }
+
+        // (2) 버퍼 설명 설정
+        D3D11_BUFFER_DESC Desc = {};
+        Desc.ByteWidth = BufferSize;
+        Desc.Usage = D3D11_USAGE_DYNAMIC;
+        Desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+        // 인덱스용이라면 D3D11_BIND_INDEX_BUFFER 로 바꿔주세요
+        Desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        Desc.MiscFlags = 0;
+        Desc.StructureByteStride = Stride;
+
+        // (3) GPU 버퍼 생성
+        HRESULT hr = Device->CreateBuffer(&Desc, nullptr, &GPUBuffer);
+        if (!SUCCEEDED(hr))
+        {
+            UE_LOG(ELogLevel::Error, TEXT("CreateBuffer failed"));
+            return;
+        }
+
+        // (4) 바로 Map 하여 쓰기 가능한 포인터 얻기
+        D3D11_MAPPED_SUBRESOURCE MappedRes;
+        Context->Map(GPUBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &MappedRes);
+        MappedBuffer = reinterpret_cast<uint8*>(MappedRes.pData);
+
+        // (5) 할당 카운트 초기화
+        AllocatedByteCount = 0;
+    }
+
+    /** Commit 직전에 호출해서 Unmap */
+    void Unmap(ID3D11DeviceContext* Context)
+    {
+        if (GPUBuffer && MappedBuffer)
+        {
+            Context->Unmap(GPUBuffer, 0);
+            MappedBuffer = nullptr;
+        }
+    }
+};
+
+template <typename DynamicBufferType>
+struct TDynamicBufferPool
+{
+    TArray<DynamicBufferType> PoolBuffers;
+    DynamicBufferType* CurrentBuffer = nullptr;
+
+    ID3D11Device* Device;
+    ID3D11DeviceContext* Context;
+
+    TDynamicBufferPool() = default;
+
+    void Initialize(ID3D11Device* InDevice, ID3D11DeviceContext* InContext)
+    {
+        Device = InDevice;
+        Context = InContext;
+    }
+
+    DynamicBufferType* Acquire(uint32 SizeInBytes, uint32 Stride)
+    {
+        const uint32 MinimumBufferSize = 65536u;
+        SizeInBytes = FMath::Max(SizeInBytes, MinimumBufferSize);
+
+        // (1) 현재 버퍼가 유효하지 않거나, 크기가 작거나, 스트라이드가 다르면
+        if (!CurrentBuffer
+            || CurrentBuffer->BufferSize < SizeInBytes
+            || CurrentBuffer->Stride != Stride)
+        {
+            // (2) 재사용 가능한 버퍼 탐색
+            for (DynamicBufferType& Buf : PoolBuffers)
+            {
+                if (Buf.BufferSize >= SizeInBytes && Buf.Stride == Stride)
+                {
+                    CurrentBuffer = &Buf;
+                    CurrentBuffer->AllocatedByteCount = 0;  // ← 여기
+                    break;
+                }
+            }
+
+            // (3) 못 찾았으면 새로 생성
+            if (!CurrentBuffer
+                || CurrentBuffer->BufferSize < SizeInBytes
+                || CurrentBuffer->Stride != Stride)
+            {
+                PoolBuffers.Emplace(SizeInBytes, Stride);
+                CurrentBuffer = &PoolBuffers.Last();
+
+                // GPU 버퍼 생성 + 맵
+                CurrentBuffer->Init(Device, Context);
+                CurrentBuffer->AllocatedByteCount = 0;  // ← 여기
+            }
+        }
+
+        return CurrentBuffer;
+    }
+};
+
+extern TDynamicBufferPool<FDynamicVertexBuffer> GDynamicVertexBufferPool;
+extern TDynamicBufferPool<FDynamicIndexBuffer>  GDynamicIndexBufferPool;
+
+struct FGlobalDynamicVertexBufferAllocation
+{
+    /** The location of the buffer in main memory. */
+    uint8* Buffer = nullptr;
+
+    /** The vertex buffer to bind for draw calls. */
+    ID3D11Buffer* VertexBuffer = nullptr;
+
+    /** The offset in to the vertex buffer. */
+    uint32 VertexOffset = 0;
+
+    /** Returns true if the allocation is valid. */
+    FORCEINLINE bool IsValid() const
+    {
+        return Buffer != nullptr;
+    }
+};
+
+/**
+ * A system for dynamically allocating GPU memory for vertices.
+ */
+class FGlobalDynamicVertexBuffer
+{
+public:
+    using FAllocation = FGlobalDynamicVertexBufferAllocation;
+
+    FGlobalDynamicVertexBuffer() = default;
+
+    ~FGlobalDynamicVertexBuffer()
+    {
+        Commit();
+    }
+
+    /**
+     * Allocates space in the global vertex buffer.
+     * @param SizeInBytes - The amount of memory to allocate in bytes.
+     * @returns An FAllocation with information regarding the allocated memory.
+     */
+    FAllocation Allocate(uint32 SizeInBytes);
+
+    /**
+     * Commits allocated memory to the GPU.
+     *		WARNING: Once this buffer has been committed to the GPU, allocations
+     *		remain valid only until the next call to Allocate!
+     */
+    void Commit();
+
+private:
+    TArray<FDynamicVertexBuffer*> VertexBuffers;
+};
+
+struct FGlobalDynamicIndexBufferAllocation
+{
+    /** The location of the buffer in main memory. */
+    uint8* Buffer = nullptr;
+
+    /** The vertex buffer to bind for draw calls. */
+    ID3D11Buffer* IndexBuffer = nullptr;
+
+    /** The offset in to the index buffer. */
+    uint32 FirstIndex = 0;
+
+    /** Returns true if the allocation is valid. */
+    FORCEINLINE bool IsValid() const
+    {
+        return Buffer != nullptr;
+    }
+};
+
+struct FGlobalDynamicIndexBufferAllocationEx : public FGlobalDynamicIndexBufferAllocation
+{
+    FGlobalDynamicIndexBufferAllocationEx(const FGlobalDynamicIndexBufferAllocation& InRef, uint32 InNumIndices, uint32 InIndexStride)
+        : FGlobalDynamicIndexBufferAllocation(InRef)
+        , NumIndices(InNumIndices)
+        , IndexStride(InIndexStride)
+    {
+    }
+
+    /** The number of indices allocated. */
+    uint32 NumIndices = 0;
+    /** The allocation stride (2 or 4 bytes). */
+    uint32 IndexStride = 0;
+    /** The maximum value of the indices used. */
+    uint32 MaxUsedIndex = 0;
+};
+
+/**
+ * A system for dynamically allocating GPU memory for indices.
+ */
+class FGlobalDynamicIndexBuffer
+{
+public:
+    using FAllocation = FGlobalDynamicIndexBufferAllocation;
+    using FAllocationEx = FGlobalDynamicIndexBufferAllocationEx;
+
+    FGlobalDynamicIndexBuffer() = default;
+
+    ~FGlobalDynamicIndexBuffer()
+    {
+        Commit();
+    }
+
+    /**
+     * Allocates space in the global index buffer.
+     * @param NumIndices - The number of indices to allocate.
+     * @param IndexStride - The size of an index (2 or 4 bytes).
+     * @returns An FAllocation with information regarding the allocated memory.
+     */
+    FAllocation Allocate(uint32 NumIndices, uint32 IndexStride);
+
+    /**
+     * Helper function to allocate.
+     * @param NumIndices - The number of indices to allocate.
+     * @returns an FAllocation with information regarding the allocated memory.
+     */
+    template <typename IndexType>
+    FORCEINLINE FAllocationEx Allocate(uint32 NumIndices)
+    {
+        return FAllocationEx(Allocate(NumIndices, sizeof(IndexType)), NumIndices, sizeof(IndexType));
+    }
+
+    /**
+     * Commits allocated memory to the GPU.
+     *		WARNING: Once this buffer has been committed to the GPU, allocations
+     *		remain valid only until the next call to Allocate!
+     */
+    void Commit();
+
+private:
+    TArray<FDynamicIndexBuffer*> IndexBuffers16;
+    TArray<FDynamicIndexBuffer*> IndexBuffers32;
+};

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/Renderer.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/Renderer.cpp
@@ -36,6 +36,8 @@
 #include "Stats/Stats.h"
 #include "Stats/GPUTimingManager.h"
 
+#include "GlobalRenderResource.h"
+
 //------------------------------------------------------------------------------
 // 초기화 및 해제 관련 함수
 //------------------------------------------------------------------------------
@@ -44,6 +46,9 @@ void FRenderer::Initialize(FGraphicsDevice* InGraphics, FDXDBufferManager* InBuf
     Graphics = InGraphics;
     BufferManager = InBufferManager;
     GPUTimingManager = InGPUTimingManager;
+
+    GDynamicVertexBufferPool.Initialize(Graphics->Device, Graphics->DeviceContext);
+    GDynamicIndexBufferPool.Initialize(Graphics->Device, Graphics->DeviceContext);
 
     ShaderManager = new FDXDShaderManager(Graphics->Device);
     ShadowManager = new FShadowManager();

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/헤더.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Renderer/헤더.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/RandEngine/RandEngine/RandEngine.vcxproj
+++ b/RandEngine/RandEngine/RandEngine.vcxproj
@@ -378,6 +378,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\fmod\lib\$(Pl
     <ClCompile Include="Engine\Source\Runtime\Renderer\EditorRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\FogRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\GizmoRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\GlobalRenderResource.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\LightHeatMapRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\LineRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcessCompositingPass.cpp" />
@@ -736,6 +737,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\fmod\lib\$(Pl
     <ClInclude Include="Engine\Source\Runtime\Renderer\EditorRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\FogRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\GizmoRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\GlobalRenderResource.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\IRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\LightHeatMapRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\LineRenderPass.h" />
@@ -752,6 +754,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\fmod\lib\$(Pl
     <ClInclude Include="Engine\Source\Runtime\Renderer\TileLightCullingPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\UpdateLightBufferPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\WorldBillboardRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\헤더.h" />
     <ClInclude Include="Engine\Source\Runtime\Serialization\Serializer.h" />
     <ClInclude Include="Engine\Source\Runtime\SlateCore\Input\Events.h" />
     <ClInclude Include="Engine\Source\Runtime\SlateCore\Widgets\SWindow.h" />

--- a/RandEngine/RandEngine/RandEngine.vcxproj.filters
+++ b/RandEngine/RandEngine/RandEngine.vcxproj.filters
@@ -1673,6 +1673,7 @@
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particle\ParticleModuleSize.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particle\ParticleModuleVelocity.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particle\ParticleSystem.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\GlobalRenderResource.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="RandEngine.natvis" />
@@ -2045,6 +2046,8 @@
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particle\ParticleModuleVelocity.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particle\ParticleSystem.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particle\ParticleSystemComponent.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\헤더.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\GlobalRenderResource.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\CompositingShader.hlsl" />


### PR DESCRIPTION
Particle을 담기 위한 GlobalDynamicBuffer 구현

Particle의 경우 매 프레임마다 계속 변경이 일어나기 때문에

기존 방식으로 버퍼를 GPU에 넘겨주게 되면
파티클 마다 버퍼를 생성하고 해제해야해서 수 많은 Map, UnMap이 일어나 병목이 생기게 됨

전역으로 거대한 버퍼를 만들어 놓고 파티클마다 그 버퍼를 잘라서 할당하고
단 한번의 Map, unMap만 일어나도록

GlobalDynamicBuffer 구현