### PR TITLE
feat: 파티클 시스템 데이터 빌드 및 캐싱 로직 구현 (Emitter, LODLevel)

### DIFF
--- a/RandEngine/RandEngine/Engine/Source/Editor/LevelEditor/SLevelEditor.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Editor/LevelEditor/SLevelEditor.cpp
@@ -467,6 +467,7 @@ void SLevelEditor::RegisterEditorInputDelegates()
 
     InputDelegatesHandles.Add(Handler->OnRawMouseInputDelegate.AddLambda([this](const FPointerEvent& InMouseEvent)
         {
+            if (::GetFocus() != GEngineLoop.AppWnd) return;
             // Mouse Move 이벤트 일때만 실행
             if (
                 InMouseEvent.GetInputEvent() == IE_Axis

--- a/RandEngine/RandEngine/Engine/Source/Editor/PropertyEditor/Sub/ParticleSystemViewerPanel.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Editor/PropertyEditor/Sub/ParticleSystemViewerPanel.cpp
@@ -1,26 +1,71 @@
 #include "ParticleSystemViewerPanel.h"
-#include "Engine/Asset/SkeletalMeshAsset.h"
-#include "SubWindow/SkeletalSubEngine.h"
+
 #include "SubWindow/SubEngine.h"
-#include "Components/Mesh/SkeletalMesh.h"
-#include "Engine/SkeletalMeshActor.h"
 #include "PropertyEditor/ShowFlags.h"
 #include "Renderer/RendererHelpers.h"
 #include "Engine/UnrealClient.h"
 #include "UnrealEd/EditorViewportClient.h"
-// ParticleSystemViewerPanel.cpp
 
+#include "Particle/ParticleSystem.h"
+#include "Particle/ParticleEmitter.h"
+#include "Particle/ParticleLODLevel.h"
+#include "Particle/ParticleModule.h"
+#include "Particle/ParticleModuleRequired.h"
+
+#include "Particle/ParticleModuleTypeDataSprite.h"
+#include "Particle/ParticleModuleTypeDataMesh.h"
+
+#include "Particle/ParticleModuleSpawn.h"
+#include "Particle/ParticleModuleLifetime.h"
 
 float ParticleSystemViewerPanel::LeftAreaTotalRatio = 0.7f;
 float ParticleSystemViewerPanel::ViewportInLeftRatio = 0.6f;
-int ParticleSystemViewerPanel::SelectedEmitterIndex = -1;
-int ParticleSystemViewerPanel::SelectedModuleIndex = -1;
 
-TArray<MyEmitterData> ParticleSystemViewerPanel::EmittersData = {
-    MyEmitterData("Sparks", true, { MyModuleData("Spawn", 100.0f, ImVec4(1,0,0,1)), MyModuleData("Lifetime", 1.0f, ImVec4(0,1,0,1)) }),
-    MyEmitterData("Smoke", true, { MyModuleData("Initial Location", 0.0f, ImVec4(0,0,1,1)), MyModuleData("Initial Velocity", 50.0f, ImVec4(1,1,0,1)) }),
-    MyEmitterData("Rain", false, { MyModuleData("Gravity", 980.0f, ImVec4(0,1,1,1))})
-};
+
+ParticleSystemViewerPanel::ParticleSystemViewerPanel()
+    : CurrentEditedSystem(nullptr)
+    , SelectedEmitterIndex_Internal(-1)
+    , SelectedModuleIndex_Internal(-1)
+    , Width(800.0f), Height(600.0f) // 생성자에서 초기화
+    , RenderTargetRHI(nullptr), DepthStencilRHI(nullptr)
+{
+    // 테스트용 기본 파티클 시스템 생성 (실제로는 파일에서 로드하거나 "새로 만들기" 메뉴로 생성)
+    CreateNewTestParticleSystem();
+}
+
+void ParticleSystemViewerPanel::SetEditedParticleSystem(UParticleSystem* System)
+{
+    CurrentEditedSystem = System;
+    if (CurrentEditedSystem)
+    {
+        CurrentEditedSystem->InitializeSystem(); // 로드/설정 시 빌드
+    }
+    SelectedEmitterIndex_Internal = -1;
+    SelectedModuleIndex_Internal = -1;
+}
+
+// 테스트용 함수
+void ParticleSystemViewerPanel::CreateNewTestParticleSystem()
+{
+    //CurrentEditedSystem = FObjectFactory::ConstructObject<UParticleSystem>(nullptr); // 적절한 Outer 제공
+    //if (CurrentEditedSystem)
+    //{
+    //    // 기본 스프라이트 이미터 추가
+    //    UParticleEmitter* Emitter = FObjectFactory::ConstructObject<UParticleEmitter>(CurrentEditedSystem);
+    //    Emitter->EmitterName = FString(TEXT("DefaultSpriteEmitter"));
+
+    //    UParticleLODLevel* LOD = FObjectFactory::ConstructObject<UParticleLODLevel>(Emitter);
+    //    LOD->RequiredModule = FObjectFactory::ConstructObject<UParticleModuleRequired>(LOD);
+    //    LOD->TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataSprite>(LOD); // 기본은 스프라이트
+    //    LOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleSpawn>(LOD));
+    //    LOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLifetime>(LOD));
+    //    Emitter->LODLevels.Add(LOD);
+    //    CurrentEditedSystem->Emitters.Add(Emitter);
+
+    //    CurrentEditedSystem->InitializeSystem();
+    //}
+}
+
 // --- 메인 렌더링 함수 ---
 void ParticleSystemViewerPanel::Render()
 {
@@ -35,6 +80,8 @@ void ParticleSystemViewerPanel::Render()
         ImGui::End();
     }
 }
+
+
 void ParticleSystemViewerPanel::PrepareRender(FEditorViewportClient* ViewportClient)
 {
     const EViewModeIndex ViewMode = ViewportClient->GetViewMode();
@@ -91,21 +138,27 @@ void ParticleSystemViewerPanel::RenderLeftPane(const ImVec2& panelSize, float sp
         // 수평 스플리터 (왼쪽 패널 내부)
         RenderHorizontalSplitter(leftAreaContentSize, splitterThickness);
 
-        // 속성 패널 (남은 공간 사용)
-        MyEmitterData* currentEmitterPtr = nullptr;
-        MyModuleData* currentModulePtr = nullptr;
-        if (SelectedEmitterIndex != -1 && SelectedEmitterIndex < EmittersData.Num())
+
+        TArray< UParticleEmitter*>& CurrentEditedEmitters = CurrentEditedSystem->Emitters;
+        UParticleEmitter* currentEmitter = nullptr;
+        UParticleModule* currentModule = nullptr;
+
+        if (CurrentEditedSystem && SelectedEmitterIndex_Internal != -1 && 
+            CurrentEditedSystem->Emitters.IsValidIndex(SelectedEmitterIndex_Internal))
         {
-            currentEmitterPtr = &EmittersData[SelectedEmitterIndex];
-            if (SelectedModuleIndex != -1 && SelectedModuleIndex < currentEmitterPtr->modules.Num())
+            currentEmitter = CurrentEditedSystem->Emitters[SelectedEmitterIndex_Internal];
+
+            if (currentEmitter && !currentEmitter->LODLevels.IsEmpty() && currentEmitter->LODLevels[0])
             {
-                currentModulePtr = &currentEmitterPtr->modules[SelectedModuleIndex];
+                UParticleLODLevel* lod = currentEmitter->LODLevels[0];
+                if (SelectedModuleIndex_Internal != -1 && lod->Modules.IsValidIndex(SelectedModuleIndex_Internal))
+                {
+                    currentModule = lod->Modules[SelectedModuleIndex_Internal];
+                }
+                // 또는 RequiredModule, TypeDataModule도 선택 대상이 될 수 있음 (UI 로직 추가 필요)
             }
         }
-        // panelSize의 y를 0으로 주면 남은 공간을 모두 사용하도록 할 수 있지만, 여기서는 명시적으로 계산된 높이를 사용.
-        // 만약 PropertiesPanel이 ViewportPanel 아래 남은 모든 공간을 차지하게 하려면
-        // ImVec2(leftAreaContentSize.x, ImGui::GetContentRegionAvail().y) 를 사용.
-        RenderPropertiesPanel(ImVec2(leftAreaContentSize.x, ImGui::GetContentRegionAvail().y), currentEmitterPtr, currentModulePtr);
+        RenderPropertiesPanel(ImVec2(leftAreaContentSize.x, ImGui::GetContentRegionAvail().y), currentEmitter, currentModule);
     }
     ImGui::EndChild(); // LeftAreaContainer_Main
 }
@@ -135,7 +188,7 @@ void ParticleSystemViewerPanel::RenderHorizontalSplitter(const ImVec2& leftAreaC
 void ParticleSystemViewerPanel::RenderRightPane(const ImVec2& panelSize)
 {
     // RenderEmitterStrip가 오른쪽 패널의 전체 내용을 그리도록 호출
-    RenderEmitterStrip(panelSize, SelectedEmitterIndex, SelectedModuleIndex, EmittersData);
+    RenderEmitterStrip(panelSize);
 }
 
 
@@ -187,10 +240,11 @@ void ParticleSystemViewerPanel::RenderViewportPanel(const ImVec2& panelSize, ImT
     ImGui::EndTabBar();
 }
 
-void ParticleSystemViewerPanel::RenderPropertiesPanel(const ImVec2& panelSize, const MyEmitterData* emitterPtr, MyModuleData* modulePtr)
-{
+void ParticleSystemViewerPanel::RenderPropertiesPanel(const ImVec2& panelSize, UParticleEmitter* SelectedEmitter, UParticleModule* DefaultSelectedModule) {
     ImVec2 actualPanelSize = panelSize;
-    if (actualPanelSize.y <= 0) { // 높이가 0 또는 음수이면 남은 공간 모두 사용
+    if (actualPanelSize.y <= 0) 
+    { 
+        // 높이가 0 또는 음수이면 남은 공간 모두 사용
         actualPanelSize.y = ImGui::GetContentRegionAvail().y;
     }
 
@@ -202,17 +256,103 @@ void ParticleSystemViewerPanel::RenderPropertiesPanel(const ImVec2& panelSize, c
         ImGui::PushStyleColor(ImGuiCol_TabActive, ImVec4(0.14f, 0.14f, 0.14f, 1.00f));   // 활성 탭
 
         ImGui::BeginTabItem("Details");
-        if (modulePtr)
+
+        const int REQUIRED_MODULE_INDEX = -2;
+        const int TYPEDATA_MODULE_INDEX = -3;
+        UParticleModule* ActualSelectedModule = DefaultSelectedModule;
+
+        if (SelectedEmitter && SelectedEmitter->GetHighestLODLevel()) 
         {
-            ImGui::Separator();
-            // modulePtr이 const MyModuleData* 이므로, 값을 변경하려면 const_cast 필요
-            ImGui::InputFloat("Value Param 1", &const_cast<MyModuleData*>(modulePtr)->value_param1);
-            ImGui::ColorEdit4("Color Param", &const_cast<MyModuleData*>(modulePtr)->color_param.x);
+            if (SelectedModuleIndex_Internal == REQUIRED_MODULE_INDEX) 
+            {
+                ActualSelectedModule = SelectedEmitter->GetHighestLODLevel()->RequiredModule;
+            }
+            else if (SelectedModuleIndex_Internal == TYPEDATA_MODULE_INDEX) {
+                ActualSelectedModule = SelectedEmitter->GetHighestLODLevel()->TypeDataModule;
+            }
         }
-        else if (emitterPtr)
+
+        if (ActualSelectedModule)
         {
+            ImGui::Text("Module: %s", *(ActualSelectedModule->GetFName().ToString())); // FName을 사용한다고 가정
             ImGui::Separator();
-            ImGui::Checkbox("활성화", &const_cast<MyEmitterData*>(emitterPtr)->is_enabled);
+
+            if (UParticleModuleSpawn* SpawnModule = Cast<UParticleModuleSpawn>(ActualSelectedModule))
+            {
+                if (ImGui::DragFloat("Spawn Rate", &SpawnModule->Rate.Constant, 0.1f, 0.0f, 1000.0f))
+                {
+                    if (CurrentEditedSystem) CurrentEditedSystem->InitializeSystem(); // 값 변경 시 재빌드
+                }
+                // BurstList 편집 UI (TArray<FParticleBurst>는 더 복잡한 UI 필요)
+                ImGui::Text("Bursts: %d", SpawnModule->BurstList.Num());
+                // ... (버스트 추가/삭제/편집 UI) ...
+            }
+            else if (UParticleModuleLifetime* LifetimeModule = Cast<UParticleModuleLifetime>(ActualSelectedModule))
+            {
+                // ... (라이프타임 모듈 프로퍼티 UI) ...
+            }
+            else if (UParticleModuleRequired* RequiredMod = Cast<UParticleModuleRequired>(ActualSelectedModule))
+            {
+                ImGui::TextUnformatted("Required Module Properties:");
+                if (ImGui::DragFloat("Emitter Duration", &RequiredMod->EmitterDuration, 0.1f, 0.0f, 1000.0f)) 
+                {
+                    if (CurrentEditedSystem) 
+                        CurrentEditedSystem->InitializeSystem();
+                }
+                if (ImGui::DragInt("Emitter Loops", &RequiredMod->EmitterLoops, 1, 0, 100)) 
+                {
+                    if (CurrentEditedSystem) CurrentEditedSystem->InitializeSystem();
+                }
+                // ... 기타 RequiredModule 프로퍼티 (Material, ScreenAlignment 등) ...
+            
+            }
+            else if (UParticleModuleTypeDataMesh* MeshTD = Cast<UParticleModuleTypeDataMesh>(ActualSelectedModule))
+            {
+                ImGui::TextUnformatted("Mesh TypeData Properties:");
+                char pathBuf[256];
+                // FString의 ToAnsiString()은 임시 객체를 반환할 수 있으므로 주의. strcpy_s 권장.
+                // 여기서는 간단히 ToAnsiString().c_str() 사용. 실제로는 버퍼 오버플로우 방지 필요.
+                strncpy_s(pathBuf, MeshTD->MeshAssetPath.ToAnsiString().c_str(), sizeof(pathBuf) - 1);
+                pathBuf[sizeof(pathBuf) - 1] = 0; // 널 종료 보장
+
+                if (ImGui::InputText("Mesh Asset Path", pathBuf, sizeof(pathBuf)))  // Mesh 설정
+                {
+                    MeshTD->MeshAssetPath = FString(pathBuf);
+                    if (CurrentEditedSystem) 
+                        CurrentEditedSystem->InitializeSystem();
+                }
+
+                if (ImGui::DragFloat3("Mesh Scale", &MeshTD->MeshScale.X, 0.01f)) 
+                { 
+                    if (CurrentEditedSystem) 
+                        CurrentEditedSystem->InitializeSystem();
+                }
+            }
+            else if (UParticleModuleTypeDataSprite* SpriteTD = Cast<UParticleModuleTypeDataSprite>(ActualSelectedModule))
+            {
+                ImGui::TextUnformatted("Sprite TypeData Properties:");
+                // 스프라이트 타입 데이터 관련 프로퍼티 (예: 기본 SubUV 설정 등)
+            }
+            else
+            {
+                ImGui::Text("Selected module type has no specific properties exposed for editing yet.");
+            }
+
+
+        }
+
+        else if (SelectedEmitter)
+        {
+            ImGui::Text("Emitter: %s", *SelectedEmitter->EmitterName);
+            ImGui::Separator();
+            // 예: 이미터 활성화 상태 편집 (LOD 0의 bEnabled)
+            if (SelectedEmitter->GetHighestLODLevel())
+            {
+                if (ImGui::Checkbox("Enabled", &SelectedEmitter->GetHighestLODLevel()->bEnabled))
+                {
+                    if (CurrentEditedSystem) CurrentEditedSystem->InitializeSystem();
+                }
+            }
         }
         else
         {
@@ -225,19 +365,20 @@ void ParticleSystemViewerPanel::RenderPropertiesPanel(const ImVec2& panelSize, c
     ImGui::EndChild(); // PropertiesPanel_BottomLeft
 }
 
-void ParticleSystemViewerPanel::RenderEmitterStrip(const ImVec2& panelSize, int& currentSelectedEmitterIdx, int& currentSelectedModuleIdx, TArray<MyEmitterData>& localEmittersData)
+void ParticleSystemViewerPanel::RenderEmitterStrip(const ImVec2& panelSize)
 {
+    if (!CurrentEditedSystem) return;
+
     ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.007, 0.007, 0.007, 1));
     bool systemHierarchyVisible = ImGui::BeginChild("SystemHierarchyPanel_Right", panelSize, ImGuiChildFlags_None);
     if (systemHierarchyVisible)
     {
-        if (ImGui::Button("선택 이미터 삭제") && currentSelectedEmitterIdx != -1 && currentSelectedEmitterIdx < localEmittersData.Num())
+        if (ImGui::Button("선택 이미터 삭제"))
         {
-            localEmittersData.RemoveAt(currentSelectedEmitterIdx);
-            currentSelectedEmitterIdx = -1;
-            currentSelectedModuleIdx = -1;
+            HandleDeleteSelectedEmitter();
         }
         ImGui::Separator();
+
 
         ImVec2 emitterStripContentSize = ImGui::GetContentRegionAvail();
         ImGuiWindowFlags emitterStripFlags = ImGuiWindowFlags_HorizontalScrollbar;
@@ -247,22 +388,25 @@ void ParticleSystemViewerPanel::RenderEmitterStrip(const ImVec2& panelSize, int&
         if (emitterStripVisible)
         {
             float fixedBlockWidth = 150.0f;
-            float blockHeight = ImGui::GetContentRegionAvail().y;
-            if (blockHeight < 50.0f) blockHeight = 50.0f; // 최소 높이 보장
-            // 패딩을 고려한 실제 블록 높이 (필요시 조정)
+
+            float blockHeight = ImGui::GetContentRegionAvail().y > 50.0f ? ImGui::GetContentRegionAvail().y : 50.0f;
             ImVec2 emitterBlockSize = ImVec2(fixedBlockWidth, blockHeight - ImGui::GetStyle().WindowPadding.y * 2.0f);
-            if (emitterBlockSize.y < 50.0f) emitterBlockSize.y = 50.0f;
-           
-          
-            AddEmitterStrip(localEmittersData);
 
-            for (int i = 0; i < localEmittersData.Num(); ++i)
+
+            HandleAddEmitterMenu();
+
+            for (int i = 0; i < CurrentEditedSystem->Emitters.Num(); ++i)
             {
-                if (i > 0) ImGui::SameLine();
+                UParticleEmitter* Emitter = CurrentEditedSystem->Emitters[i];
+                if (!Emitter) continue;
 
+                if (i > 0) ImGui::SameLine();
+                
                 ImGui::PushID(i); // 각 이미터 블록에 고유 ID 부여
 
-                bool isEmitterSelectedForFrame = (currentSelectedEmitterIdx == i && currentSelectedModuleIdx == -1);
+                bool isEmitterSelectedForFrame = (SelectedEmitterIndex_Internal == i && SelectedModuleIndex_Internal == -1);
+                
+            
                 ImVec4 childBgColor;
                 ImVec4 childBorderColorVec4;
                 if (isEmitterSelectedForFrame)
@@ -287,8 +431,8 @@ void ParticleSystemViewerPanel::RenderEmitterStrip(const ImVec2& panelSize, int&
                 bool emitterBlockFrameVisible = ImGui::BeginChild(child_id_str, emitterBlockSize, ImGuiChildFlags_Border, ImGuiWindowFlags_None);
                 if (emitterBlockFrameVisible)
                 {
-                    RenderEmitterBlockContents(i, localEmittersData[i], currentSelectedEmitterIdx, currentSelectedModuleIdx);
-                    AddModule(localEmittersData);
+                    RenderEmitterBlockContents(i, Emitter);
+                    HandleAddModuleMenu(Emitter);
                 }
                 ImGui::EndChild(); // emitter_block_frame
 
@@ -304,38 +448,129 @@ void ParticleSystemViewerPanel::RenderEmitterStrip(const ImVec2& panelSize, int&
     ImGui::PopStyleColor();
 }
 
-void ParticleSystemViewerPanel::AddEmitterStrip(TArray<MyEmitterData>& localEmittersData)
+void ParticleSystemViewerPanel::HandleAddEmitterMenu()
 {
-    if (ImGui::BeginPopupContextWindow("AddParticleContext", ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems))
+    if (!CurrentEditedSystem) return;
+
+    // EmitterStrip의 빈 공간 우클릭 시 팝업 (ImGui::BeginChild("EmitterStrip", ...) 내부에서 호출)
+    if (ImGui::BeginPopupContextWindow("AddEmitterContextWindow", ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems))
     {
-        if (ImGui::Selectable("New Particle Sprite Emitter")) // 기존 "AddParticlePopUp"의 내용
+        if (ImGui::Selectable("New Particle Sprite Emitter"))
         {
-            localEmittersData.Add(MyEmitterData("새 이미터", true));
+            UParticleEmitter* NewEmitter = FObjectFactory::ConstructObject<UParticleEmitter>(CurrentEditedSystem);
+            NewEmitter->EmitterName = FString::Printf(TEXT("SpriteEmitter_%d"), CurrentEditedSystem->Emitters.Num());
+
+            UParticleLODLevel* LOD = FObjectFactory::ConstructObject<UParticleLODLevel>(NewEmitter);
+            LOD->RequiredModule = FObjectFactory::ConstructObject<UParticleModuleRequired>(LOD);
+            LOD->TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataSprite>(LOD);
+            LOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleSpawn>(LOD));    // 기본 스폰 모듈
+            LOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLifetime>(LOD)); // 기본 라이프타임 모듈
+            NewEmitter->LODLevels.Add(LOD);
+
+            CurrentEditedSystem->Emitters.Add(NewEmitter);
+            CurrentEditedSystem->InitializeSystem(); // 시스템 재빌드
+            SelectedEmitterIndex_Internal = CurrentEditedSystem->Emitters.Num() - 1; // 새로 추가된 이미터 선택
+            SelectedModuleIndex_Internal = -1;
+        }
+        if (ImGui::Selectable("New Particle Mesh Emitter"))
+        {
+            UParticleEmitter* NewEmitter = FObjectFactory::ConstructObject<UParticleEmitter>(CurrentEditedSystem);
+            NewEmitter->EmitterName = FString::Printf(TEXT("MeshEmitter_%d"), CurrentEditedSystem->Emitters.Num());
+
+            UParticleLODLevel* LOD = FObjectFactory::ConstructObject<UParticleLODLevel>(NewEmitter);
+            LOD->RequiredModule = FObjectFactory::ConstructObject<UParticleModuleRequired>(LOD);
+            LOD->TypeDataModule = FObjectFactory::ConstructObject<UParticleModuleTypeDataMesh>(LOD); // 메시 타입 데이터
+            LOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleSpawn>(LOD));
+            LOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLifetime>(LOD));
+            NewEmitter->LODLevels.Add(LOD);
+
+            CurrentEditedSystem->Emitters.Add(NewEmitter);
+            CurrentEditedSystem->InitializeSystem();
+            SelectedEmitterIndex_Internal = CurrentEditedSystem->Emitters.Num() - 1;
+            SelectedModuleIndex_Internal = -1;
         }
         ImGui::EndPopup();
     }
 }
 
-void ParticleSystemViewerPanel::AddModule(TArray<MyEmitterData>& localEmittersData)
+void ParticleSystemViewerPanel::HandleAddModuleMenu(UParticleEmitter* TargetEmitter)
 {
+    if (!TargetEmitter || TargetEmitter->LODLevels.IsEmpty() || !TargetEmitter->LODLevels[0]) return;
+    UParticleLODLevel* TargetLOD = TargetEmitter->LODLevels[0];
 
-    if (ImGui::BeginPopupContextWindow("AddModuleContext", ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems))
+    // 이미터 블록 내부(예: 모듈 목록 아래 빈 공간) 우클릭 시 팝업
+    // RenderEmitterBlockContents 함수 내부의 적절한 위치에서 이 함수를 호출하거나,
+    // 또는 모듈 목록 영역에 대한 컨텍스트 메뉴로 처리
+    if (ImGui::BeginPopupContextItem("AddModuleContextItem")) // 특정 아이템(이미터 블록)에 대한 컨텍스트 메뉴
     {
-        ImGui::Selectable("Lifetime");
-        ImGui::Selectable("Location");
-        ImGui::Selectable("Velocity");
-        ImGui::Selectable("Color");
-        ImGui::Selectable("Size");
+        if (ImGui::Selectable("Add Lifetime Module"))
+        {
+            TargetLOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleLifetime>(TargetLOD));
+            if (CurrentEditedSystem) CurrentEditedSystem->InitializeSystem(); // 또는 TargetEmitter->Build();
+        }
+        if (ImGui::Selectable("Add Spawn Module")) // 이미 있다면 중복 추가 방지 로직 필요할 수 있음
+        {
+            TargetLOD->Modules.Add(FObjectFactory::ConstructObject<UParticleModuleSpawn>(TargetLOD));
+            if (CurrentEditedSystem) CurrentEditedSystem->InitializeSystem();
+        }
+        // ... 기타 모듈 추가 ...
         ImGui::EndPopup();
     }
 }
 
-void ParticleSystemViewerPanel::RenderEmitterBlockContents(int emitterIdx, MyEmitterData& emitterData, int& currentSelectedEmitterIdx, int& currentSelectedModuleIdx)
+void ParticleSystemViewerPanel::HandleDeleteSelectedEmitter()
 {
+    if (CurrentEditedSystem && SelectedEmitterIndex_Internal != -1 && CurrentEditedSystem->Emitters.IsValidIndex(SelectedEmitterIndex_Internal))
+    {
+        UParticleEmitter* EmitterToRemove = CurrentEditedSystem->Emitters[SelectedEmitterIndex_Internal];
+        CurrentEditedSystem->Emitters.RemoveAt(SelectedEmitterIndex_Internal);
+        // EmitterToRemove->MarkAsGarbage(); // UObject 시스템의 소멸 처리
+        SelectedEmitterIndex_Internal = -1;
+        SelectedModuleIndex_Internal = -1;
+        CurrentEditedSystem->InitializeSystem();
+    }
+}
+
+void ParticleSystemViewerPanel::HandleDeleteSelectedModule(UParticleEmitter* TargetEmitter)
+{
+    if (!CurrentEditedSystem || !TargetEmitter || TargetEmitter->LODLevels.IsEmpty() || !TargetEmitter->LODLevels[0])
+    {
+        return; // 유효하지 않은 입력 또는 상태
+    }
+
+    UParticleLODLevel* LOD = TargetEmitter->LODLevels[0];
+
+    // SelectedModuleIndex_Internal이 유효한 인덱스인지 확인
+    if (SelectedModuleIndex_Internal != -1 && LOD->Modules.IsValidIndex(SelectedModuleIndex_Internal))
+    {
+
+        LOD->Modules.RemoveAt(SelectedModuleIndex_Internal);
+
+        // 선택 상태 초기화 또는 조정
+        SelectedModuleIndex_Internal = -1;
+        // 만약 SelectedEmitterIndex_Internal이 TargetEmitter의 인덱스와 다르면 문제가 될 수 있으므로,
+        // 이 함수는 보통 현재 선택된 이미터(SelectedEmitterIndex_Internal로 식별되는)에 대해서만 작동해야 합니다.
+
+        // 변경 사항 반영을 위해 시스템 재빌드
+        CurrentEditedSystem->InitializeSystem();
+        // 또는 최소한 해당 이미터만 재빌드
+        // TargetEmitter->Build();
+        // CurrentEditedSystem->UpdateComputedFlags(); // 이미터 변경이 시스템 전체 플래그에 영향 줄 수 있음
+    }
+}
+
+void ParticleSystemViewerPanel::RenderEmitterBlockContents(int emitterIdx, UParticleEmitter* Emitter) 
+{
+    if (!Emitter || Emitter->LODLevels.IsEmpty() || !Emitter->LODLevels[0] || !Emitter->LODLevels[0]->RequiredModule)
+    {
+        return;
+    }
+    
+    UParticleLODLevel* LOD = Emitter->LODLevels[0];
+
     ImVec2 nameStartPos = ImGui::GetCursorScreenPos();
-    float emitterNamePaddingX = 6.0f;
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + emitterNamePaddingX);
-    ImGui::Text("%s", emitterData.name.c_str());
+    FString EmitterName = Emitter->EmitterName;
+    ImGui::Text("%s", EmitterName.ToAnsiString().c_str());
 
     float checkboxWidth = ImGui::GetFrameHeight();
     // 체크박스를 이름 오른쪽에 정렬하기 위한 오프셋 계산
@@ -344,14 +579,19 @@ void ParticleSystemViewerPanel::RenderEmitterBlockContents(int emitterIdx, MyEmi
     float desiredCheckboxX = ImGui::GetWindowContentRegionMax().x - checkboxWidth - ImGui::GetStyle().ItemInnerSpacing.x;
     float currentX = ImGui::GetCursorPosX(); // Text 다음에 오는 커서 X 위치
 
-    if (currentX < desiredCheckboxX) {
+    if (currentX < desiredCheckboxX) 
+    {
         ImGui::SameLine(0.0f, desiredCheckboxX - currentX);
     }
     else { // 이름이 너무 길어서 공간이 없으면 그냥 옆에 붙임
         ImGui::SameLine();
     }
 
-    ImGui::Checkbox("##Enable", &emitterData.is_enabled); // "##Enable"은 현재 ID 스택 내에서 고유 ID를 만듦
+    if(ImGui::Checkbox("##Enable", &LOD->bEnabled))
+    {
+        if (CurrentEditedSystem) 
+            CurrentEditedSystem->InitializeSystem();
+    }
 
     ImVec2 checkboxEndPos = ImGui::GetItemRectMax();
 
@@ -359,20 +599,73 @@ void ParticleSystemViewerPanel::RenderEmitterBlockContents(int emitterIdx, MyEmi
     ImGui::SetCursorScreenPos(nameStartPos);
     if (ImGui::InvisibleButton("##emitter_header_clickable", ImVec2(checkboxEndPos.x - nameStartPos.x, ImGui::GetTextLineHeightWithSpacing())))
     {
-        currentSelectedEmitterIdx = emitterIdx;
-        currentSelectedModuleIdx = -1;
+        SelectedEmitterIndex_Internal = emitterIdx;
+        SelectedModuleIndex_Internal = -1;
     }
     ImGui::SetItemAllowOverlap();
 
     ImGui::Separator();
 
-    for (int moduleIdxLoop = 0; moduleIdxLoop < emitterData.modules.Num(); ++moduleIdxLoop)
-    {
-        MyModuleData& module = emitterData.modules[moduleIdxLoop];
+    const int REQUIRED_MODULE_INDEX = -2;
+    const int TYPEDATA_MODULE_INDEX = -3;
 
+    if (LOD->RequiredModule)
+    {
+        UParticleModule* Module = LOD->RequiredModule; // 공통 타입으로 처리
+        ImGui::PushID("RequiredModule"); // 고유 ID
+
+        bool isThisModuleSelected = (SelectedEmitterIndex_Internal == emitterIdx && SelectedModuleIndex_Internal == REQUIRED_MODULE_INDEX);
+        // ... (Selectable 배경색 및 스타일 설정 로직 - 이전 답변 참고) ...
+        ImVec4 moduleSelectedBgColor = ImVec4(0.8f, 0.5f, 0.2f, 1.0f); // 선택 시 다른 색상 (예시)
+        ImVec4 moduleRegularBgColor = ImVec4(0.2f, 0.2f, 0.22f, 0.5f); // 기본 배경색 (예시)
+        // ... (PushStyleColor 등) ...
+        if (isThisModuleSelected) ImGui::PushStyleColor(ImGuiCol_Header, moduleSelectedBgColor);
+        else ImGui::PushStyleColor(ImGuiCol_Header, moduleRegularBgColor);
+        // HeaderHovered, HeaderActive도 유사하게 설정
+
+        FString ModuleDisplayName = Module->GetModuleDisplayName(); // "Required" 반환 예상
+        if (ImGui::Selectable(ModuleDisplayName.ToAnsiString().c_str(), isThisModuleSelected, ImGuiSelectableFlags_DontClosePopups, ImVec2(0, ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().FramePadding.y * 2.0f)))
+        {
+            SelectedEmitterIndex_Internal = emitterIdx;
+            SelectedModuleIndex_Internal = REQUIRED_MODULE_INDEX; // 특별 인덱스로 선택
+        }
+        if (isThisModuleSelected) ImGui::PopStyleColor(1); else ImGui::PopStyleColor(1); // Header
+        // ImGui::PopStyleColor(2); // HeaderHovered, HeaderActive도 Pop
+        ImGui::PopID();
+    }
+
+    if (LOD->TypeDataModule)
+    {
+        UParticleModule* Module = LOD->TypeDataModule; // 공통 타입으로 처리
+        ImGui::PushID("TypeDataModule");
+
+        bool isThisModuleSelected = (SelectedEmitterIndex_Internal == emitterIdx && SelectedModuleIndex_Internal == TYPEDATA_MODULE_INDEX);
+        // ... (Selectable 배경색 및 스타일 설정 로직) ...
+        ImVec4 moduleSelectedBgColor = ImVec4(0.2f, 0.5f, 0.8f, 1.0f); // 선택 시 다른 색상 (예시)
+        ImVec4 moduleRegularBgColor = ImVec4(0.2f, 0.2f, 0.22f, 0.5f); // 기본 배경색 (예시)
+        if (isThisModuleSelected) ImGui::PushStyleColor(ImGuiCol_Header, moduleSelectedBgColor);
+        else ImGui::PushStyleColor(ImGuiCol_Header, moduleRegularBgColor);
+
+        FString ModuleDisplayName = Module->GetModuleDisplayName(); // "TypeData Sprite", "TypeData Mesh" 등 반환 예상
+        if (ImGui::Selectable(ModuleDisplayName.ToAnsiString().c_str(), isThisModuleSelected, ImGuiSelectableFlags_DontClosePopups, ImVec2(0, ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().FramePadding.y * 2.0f)))
+        {
+            SelectedEmitterIndex_Internal = emitterIdx;
+            SelectedModuleIndex_Internal = TYPEDATA_MODULE_INDEX; // 특별 인덱스로 선택
+        }
+        if (isThisModuleSelected) ImGui::PopStyleColor(1); else ImGui::PopStyleColor(1);
+        ImGui::PopID();
+    }
+
+    if (LOD->RequiredModule || LOD->TypeDataModule) ImGui::Separator(); // 구분선
+    for (int moduleIdxLoop = 0; moduleIdxLoop < LOD->Modules.Num(); ++moduleIdxLoop)
+    {
+        UParticleModule* Module = LOD->Modules[moduleIdxLoop];
+        if (!Module) continue;
+
+        
         ImGui::PushID(moduleIdxLoop); // 각 모듈에 대해 고유 ID 스택 생성
 
-        bool isThisModuleSelected = (currentSelectedEmitterIdx == emitterIdx && currentSelectedModuleIdx == moduleIdxLoop);
+        bool isThisModuleSelected = (SelectedEmitterIndex_Internal == emitterIdx && SelectedModuleIndex_Internal == moduleIdxLoop);
 
         // Selectable의 레이블이 중복될 수 있으므로, PushID로 구분하거나 레이블 자체를 고유하게 만듦
 
@@ -415,14 +708,26 @@ void ParticleSystemViewerPanel::RenderEmitterBlockContents(int emitterIdx, MyEmi
         ImGui::GetWindowDrawList()->AddRectFilled(itemTopLeft, itemBottomRight, currentBgColorForRectU32);
 
         ImVec2 Size = ImVec2(0, itemHeight);
-
-        if (ImGui::Selectable(module.name.c_str(), isThisModuleSelected, ImGuiSelectableFlags_DontClosePopups, Size))
+        FString ModuleName = Module->GetModuleDisplayName();
+        if (ImGui::Selectable(ModuleName.ToAnsiString().c_str(), isThisModuleSelected, ImGuiSelectableFlags_DontClosePopups, Size))
         {
-            currentSelectedEmitterIdx = emitterIdx;
-            currentSelectedModuleIdx = moduleIdxLoop;
+            SelectedEmitterIndex_Internal = emitterIdx;
+            SelectedModuleIndex_Internal = moduleIdxLoop;
         }
         ImGui::PopStyleColor(3);
         ImGui::PopID(); // moduleIdxLoop에 대한 Pop
+    }
+    if (SelectedEmitterIndex_Internal == emitterIdx && SelectedModuleIndex_Internal != -1) 
+    {
+        if (ImGui::BeginPopupContextItem("DeleteModuleContextItem")) 
+        { 
+            // 현재 선택된 모듈 아이템 위에서 우클릭
+            if (ImGui::Selectable("Delete Selected Module")) 
+            {
+                HandleDeleteSelectedModule(Emitter);
+            }
+            ImGui::EndPopup();
+        }
     }
 }
 

--- a/RandEngine/RandEngine/Engine/Source/Editor/PropertyEditor/Sub/ParticleSystemViewerPanel.h
+++ b/RandEngine/RandEngine/Engine/Source/Editor/PropertyEditor/Sub/ParticleSystemViewerPanel.h
@@ -3,54 +3,54 @@
 #include "UnrealEd/EditorPanel.h"
 #include "UnrealEd/EditorViewportClient.h"
 
-// 예시 이미터 데이터 구조체
-struct MyModuleData {
-    std::string name;
-    // ... 모듈 타입별 다양한 속성들 ...
-    float value_param1;
-    ImVec4 color_param;
-    // 어떤 타입의 모듈인지 식별자 추가 가능 (예: enum ModuleType)
-
-    MyModuleData(std::string n, float v1, ImVec4 c) : name(n), value_param1(v1), color_param(c) {}
-};
-struct MyEmitterData {
-    std::string name;
-    bool is_enabled;
-    TArray<MyModuleData> modules;
-    // ... 기타 이미터 속성 ...
-};
 struct FRenderTargetRHI;
 struct FDepthStencilRHI;
+
+class UParticleSystem;
+class UParticleModule;
+class UParticleEmitter;
 
 class ParticleSystemViewerPanel : public UEditorPanel // UEditorPanel이 정의되어 있어야 함
 {
 public:
+    ParticleSystemViewerPanel();
     void PrepareRender(FEditorViewportClient* ViewportClient);
     virtual void Render() override;
     virtual void OnResize(HWND hWnd) override; // HWND는 Windows 특정 타입
 
+    void SetEditedParticleSystem(UParticleSystem* System);
+    void CreateNewTestParticleSystem();//TEST 용
+public:
+    UParticleSystem* CurrentEditedSystem;
 private:
     // UI 상태 및 비율 변수
     static float LeftAreaTotalRatio;
     static float ViewportInLeftRatio;
-    static int SelectedEmitterIndex;
-    static int SelectedModuleIndex;
-    static TArray<MyEmitterData> EmittersData; // 데이터
 
-    // 레이아웃 관리 헬퍼 함수
+    int SelectedEmitterIndex_Internal;
+    int SelectedModuleIndex_Internal;
+    
     void RenderMainLayout(const ImVec2& canvasContentSize);
     void RenderLeftPane(const ImVec2& panelSize, float splitterThickness, float minPanelSize);
     void RenderVerticalSplitter(const ImVec2& canvasContentSize, float splitterThickness);
     void RenderHorizontalSplitter(const ImVec2& leftAreaContentSize, float splitterThickness);
     void RenderRightPane(const ImVec2& panelSize);
 
-    // 기존 패널 렌더링 함수들 (static 유지)
+    // 개별 UI 패널 렌더링 함수들
     void RenderViewportPanel(const ImVec2& panelSize, ImTextureID textureId, float originalImageWidth, float originalImageHeight);
-    void RenderPropertiesPanel(const ImVec2& panelSize, const MyEmitterData* emitterPtr, MyModuleData* modulePtr);
-    void RenderEmitterBlockContents(int emitterIdx, MyEmitterData& emitterData, int& currentSelectedEmitterIdx, int& currentSelectedModuleIdx);
-    void RenderEmitterStrip(const ImVec2& panelSize, int& currentSelectedEmitterIdx, int& currentSelectedModuleIdx, TArray<MyEmitterData>& localEmittersData);
-    void AddEmitterStrip(TArray<MyEmitterData>& localEmittersData);
-    void AddModule(TArray<MyEmitterData>& localEmittersData);
+    // RenderPropertiesPanel은 실제 UObject 포인터를 받도록 시그니처 변경
+    void RenderPropertiesPanel(const ImVec2& panelSize, UParticleEmitter* SelectedEmitter, UParticleModule* SelectedModule);
+    // RenderEmitterStrip은 UParticleSystem 포인터를 받거나 멤버 CurrentEditedSystem을 직접 사용
+    void RenderEmitterStrip(const ImVec2& panelSize);
+    // RenderEmitterBlockContents는 UParticleEmitter 참조/포인터를 받음
+    void RenderEmitterBlockContents(int emitterIdx, UParticleEmitter* Emitter);
+
+    // 이미터/모듈 추가/삭제를 위한 메뉴 핸들러 함수들
+    void HandleAddEmitterMenu(); // AddEmitterStrip에서 이름 변경 및 기능 분리
+    void HandleAddModuleMenu(UParticleEmitter* TargetEmitter); // AddModule에서 이름 변경 및 기능 분리
+    void HandleDeleteSelectedEmitter();
+    void HandleDeleteSelectedModule(UParticleEmitter* TargetEmitter);
+
     // HWND 크기 (OnResize에서 설정)
     float Width = 800.0f;  // 적절한 초기값 설정
     float Height = 600.0f; // 적절한 초기값 설정

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Core/Math/DistributionFloat.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Core/Math/DistributionFloat.cpp
@@ -1,0 +1,3 @@
+#include "DistributionFloat.h"
+#include "Misc/Parse.h"
+

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Core/Math/DistributionFloat.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Core/Math/DistributionFloat.h
@@ -1,0 +1,107 @@
+#pragma once
+#include "UObject/NameTypes.h"
+#include "MathUtility.h"
+
+enum class EDistributionType : uint8 // 명시적으로 기본 타입 지정 가능
+{
+    Constant,
+    Uniform,
+    Curve,
+    Parameter,
+};
+
+struct FDistributionFloat
+{
+    EDistributionType DistributionType;
+
+    float Constant;
+
+    float Min;
+
+    float Max;
+
+
+    FName ParameterName; // 파라미터 이름
+
+    // 생성자에서 기본값 설정
+    FDistributionFloat()
+        : DistributionType(EDistributionType::Constant)
+        , Constant(0.0f)
+        , Min(0.0f)
+        , Max(1.0f)
+        , ParameterName(NAME_None) // FName의 기본값
+    {
+    }
+
+    // 특정 시간 및 컨텍스트에서 실제 float 값을 가져오는 함수
+    float GetValue(float InTime = 0.0f) const
+    {
+        switch (DistributionType)
+        {
+        case EDistributionType::Constant:
+            return Constant;
+
+        case EDistributionType::Uniform:
+        {
+            return FMath::FRandRange(Min, Max);
+        }
+
+        case EDistributionType::Curve:
+            // if (Curve)
+            // {
+            //     return Curve->GetFloatValue(InTime); // UCurveFloat의 함수 호출
+            // }
+            // UE_LOG(LogTemp, Warning, TEXT("FDistributionFloat::GetValue - Curve is null for Curve distribution."));
+            return Constant; // 커브가 없으면 Constant 값 반환 (또는 0)
+
+        case EDistributionType::Parameter:
+            // if (ParamOwner && ParameterName != NAME_None)
+            // {
+            //     // ParamOwner에서 ParameterName을 가진 float 프로퍼티를 찾아서 반환하는 로직 필요
+            //     // (리플렉션 또는 특정 인터페이스 기반)
+            //     // 예: return UGameplayStatics::GetFloatAttribute(ParamOwner, ParameterName);
+            // }
+            // UE_LOG(LogTemp, Warning, TEXT("FDistributionFloat::GetValue - Parameter '%s' not found or ParamOwner is null."), *ParameterName.ToString());
+            return Constant; // 파라미터를 못 찾으면 Constant 값 반환 (또는 0)
+        }
+        return Constant; // 기본적으로 Constant 값 반환
+    }
+
+    // 분포가 상수인지 확인 (에디터 등에서 사용)
+    bool IsConstant() const
+    {
+        return DistributionType == EDistributionType::Constant;
+    }
+
+    // 상수 값을 직접 가져오기 (IsConstant()가 true일 때만 안전)
+    float GetConstantValue() const
+    {
+        return Constant;
+    }
+
+    // 분포에서 가능한 (또는 대표적인) 최대값을 가져오려는 시도 (추정치 계산 등에 사용)
+    float GetMaxValue() const
+    {
+        switch (DistributionType)
+        {
+        case EDistributionType::Constant:
+            return Constant;
+        case EDistributionType::Uniform:
+            return Max;
+        case EDistributionType::Curve:
+            // if (Curve)
+            // {
+            //     float MinVal, MaxVal;
+            //     Curve->GetTimeRange(MinVal, MaxVal); // 커브의 시간 범위
+            //     // 실제로는 커브의 값 범위를 가져와야 함
+            //     // return Curve->GetValueRange(MinVal, MaxVal).Max; // 예시
+            //     return Constant; // 단순화를 위해 일단 Constant 반환
+            // }
+            return Constant;
+        case EDistributionType::Parameter:
+            // 파라미터의 최대값을 알 수 없으므로, 보수적으로 Constant나 특정 기본값 반환
+            return Constant;
+        }
+        return Constant;
+    }
+};

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Core/Math/MathUtility.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Core/Math/MathUtility.h
@@ -3,12 +3,12 @@
 #include <concepts>
 #include <numbers>
 #include <random>
+#include <chrono>
 #include <type_traits>
 
 #include "MathFwd.h"
 #include "MathSSE.h"
 #include "Core/HAL/PlatformType.h"
-
 
 #define PI                   (3.1415926535897932f)
 #define SMALL_NUMBER         (1.e-8f)
@@ -38,6 +38,12 @@
  *     }
  * }
  */
+namespace 
+{
+    // 스레드 안전성이 필요하다면 thread_local 또는 다른 동기화 메커니즘 고려
+    static std::mt19937 GSharedRandomEngine(static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+}
+
 template <typename T>
 struct TCustomLerp
 {
@@ -634,4 +640,39 @@ struct FMath
 
     static FORCEINLINE bool IsInf(float x) { return !_finite(x); }
     static FORCEINLINE bool IsNaN(float A) { return _isnan(A); }
+
+    [[nodiscard]] static FORCEINLINE float FRand()
+    {
+        // std::uniform_real_distribution은 [a, b) 범위의 실수를 생성합니다.
+        std::uniform_real_distribution<float> Dist(0.0f, 1.0f);
+        return Dist(GSharedRandomEngine); // 익명 네임스페이스의 전역 엔진 사용
+    }
+
+    [[nodiscard]] static FORCEINLINE float FRandRange(float InMin, float InMax)
+    {
+        // FRand()의 결과는 [0.0, 1.0) 이므로, InMax는 포함되지 않습니다.
+        // 만약 InMax를 포함하고 싶다면, 미세한 조정이 필요하거나
+        // std::uniform_real_distribution<float> Dist(InMin, std::nextafter(InMax, std::numeric_limits<float>::infinity()));
+        // 와 같은 방식을 고려할 수 있지만, 대부분의 경우 FRand() 기반이면 충분합니다.
+        return InMin + (InMax - InMin) * FRand();
+    }
+
+    /**
+     * 0 이상 Max-1 이하의 균등 분포된 int32 난수를 반환합니다.
+     */
+    [[nodiscard]] static FORCEINLINE int32 RandRange(int32 Min, int32 Max)
+    {
+        if (Min >= Max)
+        {
+            return Min;
+        }
+        // std::uniform_int_distribution은 [a, b] 범위의 정수를 생성합니다.
+        std::uniform_int_distribution<int32> Dist(Min, Max - 1); // Max는 미포함이므로 Max-1
+        return Dist(GSharedRandomEngine);
+    }
+
+    /**
+     * 0 이상 Max-1 이하의 균등 분포된 int32 난수를 반환합니다. (Max 단일 인자 버전)
+     */
+   
 };

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleEmitter.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleEmitter.h
@@ -41,16 +41,19 @@ public:
     TArray<UParticleLODLevel*> LODLevels; // 실제로는 LODLevels[0]만 사용
 
     // --- CacheEmitterModuleInfo 결과 저장용 멤버 ---
-    bool bRequiresLoopNotification;
-    bool bMeshRotationActive; // 메시 회전이 필요한지 여부 (주로 TouchesMeshRotation() 결과)
-    TMap<UParticleModule*, int32> ModuleOffsetMap; // 파티클 데이터 내 모듈 페이로드 오프셋
-    TMap<UParticleModule*, int32> ModuleInstanceOffsetMap; // 이미터 인스턴스 데이터 내 모듈 페이로드 오프셋
-    TArray<UParticleModule*> ModulesNeedingInstanceData; // 인스턴스 데이터가 필요한 모듈 목록
-    int32 DynamicParameterDataOffset; // UParticleModuleParameterDynamic 지원 시 페이로드 오프셋
-    int32 ParticleSize; // 최종 계산된 단일 파티클의 총 크기 (FBaseParticle + 모든 모듈 페이로드)
-    int32 ReqInstanceBytes; // 이미터 인스턴스당 필요한 총 추가 바이트
-    int32 TypeDataOffset; // TypeDataModule 페이로드의 시작 오프셋
-    int32 TypeDataInstanceOffset; // TypeDataModule의 인스턴스별 데이터 오프셋
+    bool bRequiresLoopNotification_Cached;
+    bool bMeshRotationActive_Cached;
+
+    TMap<UParticleModule*, int32>ModuleOffsetMap_Cached; // 파티클 데이터 내 각 모듈 페이로드의 시작 오프셋 (FBaseParticle 이후)
+    TMap<UParticleModule*, int32> ModuleInstanceOffsetMap_Cached; // 이미터 인스턴스 데이터 내 각 모듈 페이로드의 시작 오프셋
+    TArray<UParticleModule*> ModulesNeedingInstanceData_Cached; // 인스턴스 데이터가 필요한 모듈 목록
+
+    int32 EstimatedMaxActiveParticles_Cached; // 예상 최대 활성 파티클 수 (BuildInfo로부터 가져옴)
+  
+    int32 ParticleSize_Cached;            // 최종 계산된 단일 파티클의 총 메모리 크기
+    int32 ReqInstanceBytes_Cached;        // 이미터 인스턴스당 필요한 총 추가 바이트 (모든 모듈 합산)
+    int32 TypeDataOffset_Cached;          // TypeDataModule 페이로드의 시작 오프셋 (ParticleSize_Cached 내)
+    int32 TypeDataInstanceOffset_Cached;  // TypeDataModule의 인스턴스별 데이터 오프셋 (ReqInstanceBytes_Cached 내)
 
 public:
     UParticleEmitter();

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleLODLevel.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleLODLevel.cpp
@@ -1,60 +1,193 @@
 #include "ParticleLODLevel.h"
 #include "ParticleEmitter.h"
+#include "ParticleModule.h"
 #include "UObject/Casts.h"
+
+#include "ParticleModuleSpawn.h"
+#include "ParticleModuleLifetime.h"
+#include "ParticleModuleRequired.h"
+#include "ParticleModuleTypeDataBase.h"
+
 
 int32 UParticleLODLevel::CalculateMaxActiveParticleCount()
 {
-     //실제 구현에서는 RequiredModule, SpawnModule, LifetimeModule 등을 참조하여 계산
-     //float SpawnRate = 0.0f;
-     //float Lifetime = 1.0f;
-     //if (RequiredModule) { /* ... */ }
-     //for (UParticleModule* Mod : Modules) {
-     //    if (UParticleModuleSpawn* SpawnMod = Cast<UParticleModuleSpawn>(Mod)) {
-     //         SpawnRate = SpawnMod->Rate.GetValue(); // 분포 값 가져오기
-     //    } else if (UParticleModuleLifetime* LifetimeMod = Cast<UParticleModuleLifetime>(Mod)) {
-     //         Lifetime = LifetimeMod->Lifetime.GetValue();
-     //    }
-     //}
-     //return static_cast<int32>(SpawnRate * Lifetime) + 10; // 매우 단순화된 예시
-    return 50; // 임시 값
-}
-void UParticleLODLevel::CompileModules(FParticleEmitterBuildInfo& EmitterBuildInfo)
-{
-    EmitterBuildInfo.OwningLODLevel = this;
-    EmitterBuildInfo.RequiredModule = this->RequiredModule;
-    EmitterBuildInfo.CurrentTypeDataModule = this->TypeDataModule;
-
-    // Spawn 모듈 찾아서 할당 (Modules 배열에 있다고 가정)
-    EmitterBuildInfo.SpawnModule = nullptr; // 기본값
-    for (UParticleModule* Mod : this->Modules)
+    if (!RequiredModule)
     {
-        //if (UParticleModuleSpawn* SpawnMod = Cast<UParticleModuleSpawn>(Mod)) // Cast가 작동한다고 가정
-        //{
-        //    EmitterBuildInfo.SpawnModule = SpawnMod;
-        //    break;
-        //}
+        return 0;
     }
 
-    // 예상 최대 파티클 수 계산
-    EmitterBuildInfo.EstimatedMaxActiveParticleCount = CalculateMaxActiveParticleCount();
+    float ParticleMaxLifetime = 0.0f;
+    float EffectiveSpawnRate = 0.0f;
+    int32 TotalBurstAmountFromSpawnModule = 0;
 
-    // TypeDataModule이 메시 타입이라면, 메시 경로 같은 추가 정보를 EmitterBuildInfo에 설정할 수 있음
-    // (하지만 UParticleModuleTypeDataMesh::Build 에서 직접 MeshAssetPath를 사용하므로 여기서는 필수 아님)
-    // if (this->TypeDataModule)
-    // {
-    //     if (UParticleModuleTypeDataMesh* MeshTypeData = Cast<UParticleModuleTypeDataMesh>(this->TypeDataModule))
-    //     {
-    //         // EmitterBuildInfo 에는 이미 CurrentTypeDataModule 로 TypeDataModule 참조가 있으므로,
-    //         // UParticleModuleTypeDataMesh::Build 에서 직접 MeshTypeData->MeshAssetPath 접근 가능.
-    //         // 특별히 EmitterBuildInfo 에 중복해서 넣을 필요는 없을 수 있음.
-    //     }
-    // }
+    // Modules 배열에서 Spawn 및 Lifetime 모듈 찾기
+    UParticleModuleSpawn* SpawnModule = nullptr;
+    UParticleModuleLifetime* LifetimeModule = nullptr;
 
-    // (선택적) 다른 일반 모듈들의 CompileModule 호출
-    // if (this->RequiredModule) this->RequiredModule->CompileModule(EmitterBuildInfo);
-    // if (EmitterBuildInfo.SpawnModule) EmitterBuildInfo.SpawnModule->CompileModule(EmitterBuildInfo);
-    // for (UParticleModule* Mod : this->Modules)
-    // {
-    //     if (Mod) Mod->CompileModule(EmitterBuildInfo);
-    // }
+    for (UParticleModule* mod : Modules)
+    {
+        if (mod && mod->bEnabled) // 유효하고 활성화된 모듈만 고려
+        {
+            if (!SpawnModule) // 아직 스폰 모듈 못 찾음
+            {
+                SpawnModule = Cast<UParticleModuleSpawn>(mod);
+            }
+            if (!LifetimeModule) // 아직 라이프타임 모듈 못 찾음
+            {
+                LifetimeModule = Cast<UParticleModuleLifetime>(mod);
+            }
+            if (SpawnModule && LifetimeModule) break; // 둘 다 찾았으면 종료
+        }
+    }
+
+    // 스폰 모듈에서 정보 가져오기
+    if (SpawnModule)
+    {
+        EffectiveSpawnRate = SpawnModule->GetEffectiveSpawnRate(0.0f); // 이미터 시간 0에서의 스폰율 (또는 분포의 최대/평균)
+        TotalBurstAmountFromSpawnModule = SpawnModule->GetTotalBurstAmountSimple();
+    }
+    else 
+    { 
+        UE_LOG(ELogLevel::Warning, TEXT("CalculateMaxActiveParticleCount: SpawnModule not found or disabled."));
+    }
+
+
+    // 라이프타임 모듈에서 정보 가져오기
+    if (LifetimeModule) // Cast 성공 및 활성화는 위에서 체크됨
+    {
+        ParticleMaxLifetime = LifetimeModule->GetMaxLifetime();
+    }
+    else
+    {
+        // 라이프타임 모듈이 없으면 파티클이 즉시 사라지거나,
+        // RequiredModule에 기본 수명이 있다면 그것을 사용할 수 있음.
+        // 여기서는 0으로 처리하여, 버스트가 없다면 파티클이 없는 것으로 간주.
+        // UE_LOG(LogTemp, Warning, TEXT("CalculateMaxActiveParticleCount: LifetimeModule not found or disabled. Particle lifetime will be 0."));
+        ParticleMaxLifetime = 0.0f; // 또는 적절한 기본값 (예: 1.0f)
+    }
+
+    // --- 실제 계산 로직 ---
+
+    // 수명이 0이거나 음수이고 버스트도 없으면 활성 파티클 없음
+    if (ParticleMaxLifetime <= 0.0f && TotalBurstAmountFromSpawnModule == 0)
+    {
+        return 0;
+    }
+    // 수명이 0이거나 음수이지만 버스트가 있다면, 버스트 파티클만 존재
+    if (ParticleMaxLifetime <= 0.0f && TotalBurstAmountFromSpawnModule > 0)
+    {
+        return TotalBurstAmountFromSpawnModule;
+    }
+    // 스폰율이 0이고 버스트만 있다면, 버스트 파티클만 존재
+    if (EffectiveSpawnRate <= 0.0f && TotalBurstAmountFromSpawnModule > 0)
+    {
+        return TotalBurstAmountFromSpawnModule;
+    }
+    // 스폰율도 없고 버스트도 없으면 활성 파티클 없음
+    if (EffectiveSpawnRate <= 0.0f && TotalBurstAmountFromSpawnModule == 0)
+    {
+        return 0;
+    }
+
+
+    float emitterDuration = RequiredModule->EmitterDuration;
+    int32 emitterLoops = RequiredModule->EmitterLoops;
+    int32 calculatedMaxActiveParticles = 0;
+
+    // 1. 지속 스폰으로 인한 최대 파티클 수
+    if (EffectiveSpawnRate > 0.0f)
+    {
+        bool bInfiniteDurationOrLoops = (emitterLoops == 0 || emitterDuration <= 0.0f);
+        if (bInfiniteDurationOrLoops)
+        {
+            calculatedMaxActiveParticles = FMath::CeilToInt(EffectiveSpawnRate * ParticleMaxLifetime);
+        }
+        else // 유한 루프 및 유효한 지속 시간
+        {
+            float totalPlayTime = emitterDuration * emitterLoops;
+            if (ParticleMaxLifetime >= totalPlayTime)
+            {
+                calculatedMaxActiveParticles = FMath::CeilToInt(EffectiveSpawnRate * totalPlayTime);
+            }
+            else
+            {
+                calculatedMaxActiveParticles = FMath::CeilToInt(EffectiveSpawnRate * ParticleMaxLifetime);
+            }
+        }
+    }
+
+    // 2. 버스트로 인한 파티클 수 추가
+    //    - 가장 단순한 방법: 모든 버스트 파티클이 한 번에 추가된다고 가정.
+    //    - 더 정확하게 하려면: 이미터 루프와 파티클 수명을 고려하여 버스트가 중첩될 수 있는지 판단.
+    //      (예: 루프 N번, 각 루프 시작 시 버스트, 파티클 수명이 루프 길이보다 짧으면 중첩 가능)
+    //      여기서는 단순 합산.
+    calculatedMaxActiveParticles += TotalBurstAmountFromSpawnModule;
+
+    // 3. 최종 값 보정
+    if (calculatedMaxActiveParticles > 0)
+    {
+        return FMath::Max(1, calculatedMaxActiveParticles); // 최소 1개 보장
+    }
+
+    return 0; // 모든 조건에 해당하지 않으면 0
+}
+
+void UParticleLODLevel::CompileModules(FParticleEmitterBuildInfo& OutEmitterBuildInfo) // 파라미터 이름을 Out으로 변경하여 의도 명확화
+{
+    // 0. 방어 코드
+    if (!RequiredModule)
+    {
+        OutEmitterBuildInfo.EstimatedMaxActiveParticleCount = 0;
+        return;
+    }
+
+    // 1. FParticleEmitterBuildInfo의 기본 참조 설정
+    OutEmitterBuildInfo.OwningLODLevel = this;
+    OutEmitterBuildInfo.RequiredModule = this->RequiredModule;
+    OutEmitterBuildInfo.CurrentTypeDataModule = this->TypeDataModule; // TypeDataModule이 null일 수도 있음
+
+    // 2. SpawnModule 찾아서 BuildInfo에 설정 (Modules 배열 내에서)
+    OutEmitterBuildInfo.SpawnModule = nullptr; // 초기화
+    for (UParticleModule* Mod : this->Modules)
+    {
+        if (Mod && Mod->bEnabled) // 유효하고 활성화된 모듈만
+        {
+            if (UParticleModuleSpawn* SpawnMod = Cast<UParticleModuleSpawn>(Mod))
+            {
+                OutEmitterBuildInfo.SpawnModule = SpawnMod;
+                break;
+            }
+        }
+    }
+
+    // 3. 예상 최대 활성 파티클 수 계산 및 설정
+    OutEmitterBuildInfo.EstimatedMaxActiveParticleCount = CalculateMaxActiveParticleCount();
+
+    // 4. 각 중요 모듈 및 일반 모듈의 CompileModule 함수 호출
+    //    호출 순서는 모듈 간 의존성에 따라 중요할 수 있습니다.
+    //    일반적으로 Required -> Spawn -> 일반 Modules -> TypeData 순서 또는
+    //    Required -> 일반 Modules (Spawn 포함) -> TypeData 순서가 될 수 있습니다.
+    //    여기서는 Required -> Modules (Spawn 포함) -> TypeData 순서로 가정합니다.
+
+    // 4.1. RequiredModule 컴파일
+    //      (RequiredModule은 항상 존재하고 활성화되어 있다고 가정, 또는 여기서 bEnabled 체크)
+    this->RequiredModule->CompileModule(OutEmitterBuildInfo);
+
+    // 4.2. Modules 배열에 있는 모든 활성화된 일반 모듈들 컴파일
+    //      (여기에 SpawnModule도 포함되어 한 번만 호출됨)
+    for (UParticleModule* Mod : this->Modules)
+    {
+        if (Mod && Mod->bEnabled)
+        {
+            // TypeDataModule은 Modules 배열에 없다고 가정하고, 별도로 처리합니다.
+            Mod->CompileModule(OutEmitterBuildInfo);
+        }
+    }
+
+    // 4.3. TypeDataModule 컴파일 (존재하고 활성화된 경우)
+    //      다른 모든 모듈의 정보가 BuildInfo에 어느 정도 채워진 후 호출될 수 있습니다.
+    if (this->TypeDataModule && this->TypeDataModule->bEnabled)
+    {
+        this->TypeDataModule->CompileModule(OutEmitterBuildInfo);
+    }
 }

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleLODLevel.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleLODLevel.h
@@ -13,7 +13,7 @@ class UParticleLODLevel : public UObject
     DECLARE_CLASS(UParticleLODLevel, UObject);
 
 public:
-    // int32 Level; // LOD 0만 사용하므로 이 멤버는 불필요하거나 항상 0
+ 
     bool bEnabled; // 이 LOD 레벨이 활성화되었는지 여부
 
     UParticleModuleRequired* RequiredModule;
@@ -23,9 +23,9 @@ public:
     UParticleModuleTypeDataBase* TypeDataModule;
 
     UParticleLODLevel() : bEnabled(true), RequiredModule(nullptr), TypeDataModule(nullptr) {}
+    
     int32 CalculateMaxActiveParticleCount();
+   
     // 에디터 기능: 빌드 정보 수집
     void CompileModules(FParticleEmitterBuildInfo& EmitterBuildInfo);
-    // (선택적) 최대 활성 파티클 수 계산
-    // int32 CalculateMaxActiveParticleCount();
 };

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModule.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModule.h
@@ -20,11 +20,37 @@ public:
 
     // --- 모듈 타입 식별 ---
     virtual EModuleType GetModuleType() const { return EModuleType::Base; }
+    virtual FString GetModuleDisplayName() const
+    {
+        switch (GetModuleType())
+        {
+            case EModuleType::Required:
+                return TEXT("Required");
+            case EModuleType::Base:
+                return TEXT("Base");
+            case EModuleType::Spawn:
+                return TEXT("Spawn");
+            case EModuleType::Color:
+                return TEXT("Color");
+            case EModuleType::Velocity:
+                return TEXT("Velocity");
+            case EModuleType::Size:
+                return TEXT("Size");
+            case EModuleType::Lifetime:
+                return TEXT("Lifetime");
+            case EModuleType::TypeDataMesh:
+                return TEXT("TypeDataMesh");
+            case EModuleType::TypeDataSprite:
+                return TEXT("TypeDataSprite");
+            default:
+                return TEXT("Unknown");
 
+        }
+    }
     // --- 파티클 데이터 요구량 ---
     // 이 모듈이 파티클별 데이터(FBaseParticle 이후에 붙는)에 필요한 바이트 수
     virtual int32 RequiredBytes(UParticleModuleTypeDataBase* /*SpawningTypeData*/) const { return 0; }
-   
+
     // 이 모듈이 이미터 인스턴스별 데이터에 필요한 바이트 수
     virtual int32 RequiredBytesPerInstance() const { return 0; }
 

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleLifetime.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleLifetime.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ParticleModule.h"
-
+#include "Math/DistributionFloat.h"
 class UParticleModuleLifetime : public UParticleModule
 {
     DECLARE_CLASS(UParticleModuleLifetime, UParticleModule);
@@ -8,6 +8,14 @@ class UParticleModuleLifetime : public UParticleModule
 public:
     UParticleModuleLifetime();
     ~UParticleModuleLifetime() override = default;
-
+    FDistributionFloat Lifetime;
+    float GetMaxLifetime() const
+    {
+        if (Lifetime.IsConstant()) 
+            return Lifetime.GetConstantValue(); 
+        else 
+            return Lifetime.GetMaxValue();
+    }
+    virtual EModuleType GetModuleType() const override { return EModuleType::Lifetime; }
 };
 

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleSpawn.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleSpawn.cpp
@@ -1,1 +1,48 @@
 #include "ParticleModuleSpawn.h"
+
+float UParticleModuleSpawn::GetEffectiveSpawnRate(float EmitterTime) const
+{
+    if (!bProcessSpawnRate || !bEnabled)
+    {
+        return 0.0f;
+    }
+
+    // FDistributionFloat의 GetValue 함수를 사용하여 현재 시간의 스폰율과 스케일 값을 가져옵니다.
+    // OwnerContext는 Parameter 타입 분포를 사용할 경우 필요할 수 있습니다.
+    float BaseRate = Rate.GetValue(EmitterTime);
+    float Scale = RateScale.GetValue(EmitterTime);
+
+    return BaseRate * Scale;
+}
+
+int32 UParticleModuleSpawn::GetBurstAmountForThisTick(float EmitterTime, float DeltaTime) const
+{
+    if (!bProcessBurstList || !bEnabled || BurstList.IsEmpty() || DeltaTime <= 0.0f)
+    {
+        return 0;
+    }
+
+    int32 TotalBurstParticlesThisTick = 0;
+    float PreviousEmitterTime = EmitterTime - DeltaTime;
+
+    for (const FParticleBurst& Burst : BurstList)
+    {
+        if (Burst.Time > PreviousEmitterTime && Burst.Time <= EmitterTime)
+        {
+            TotalBurstParticlesThisTick += Burst.Count;
+        }
+        else if (PreviousEmitterTime < 0 && Burst.Time == 0.0f && EmitterTime >= 0.0f) // 첫 프레임 Time=0 버스트
+        {
+            TotalBurstParticlesThisTick += Burst.Count;
+        }
+    }
+    return TotalBurstParticlesThisTick;
+}
+
+int32 UParticleModuleSpawn::GetTotalBurstAmountSimple() const
+{
+    if (!bProcessBurstList || !bEnabled) return 0;
+    int32 Total = 0;
+    for (const FParticleBurst& Burst : BurstList) { Total += Burst.Count; }
+    return Total;
+}

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleSpawn.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleSpawn.h
@@ -1,13 +1,13 @@
 #pragma once
 #include "ParticleModule.h"
+#include "Math/DistributionFloat.h"
+
 
 // 간단한 파티클 버스트 구조체
 struct FParticleBurst
 {
-    int32 Count;    // 한 번에 생성할 파티클 수
-    float Time;     // 이미터 시작 후 버스트가 발생할 시간
-    // int32 CountLow; // 최소/최대 범위로 스폰할 경우 (선택적)
-
+    int32 Count;
+    float Time;
     FParticleBurst() : Count(0), Time(0.0f) {}
 };
 
@@ -17,8 +17,8 @@ class UParticleModuleSpawn : public UParticleModule
 
 public:
     // 파티클 생성 속도 (초당 파티클 수)
-    float Rate; 
-    float RateScale;
+    FDistributionFloat Rate;
+    FDistributionFloat RateScale;
 
     // 버스트 목록
     TArray<FParticleBurst> BurstList;
@@ -31,16 +31,31 @@ public:
         : bProcessSpawnRate(true)
         , bProcessBurstList(true)
     {
-        // Rate, RateScale 기본값 설정 (예: 상수 분포로 10개/초)
-        // Rate.Distribution = NewObject<UDistributionFloatConstant>();
-        // Cast<UDistributionFloatConstant>(Rate.Distribution)->Constant = 10.0f;
-        // RateScale.Distribution = NewObject<UDistributionFloatConstant>();
-        // Cast<UDistributionFloatConstant>(RateScale.Distribution)->Constant = 1.0f;
+        Rate.DistributionType = EDistributionType::Constant;
+        Rate.Constant = 10.0f;
+
+        RateScale.DistributionType = EDistributionType::Constant;
+        RateScale.Constant = 1.0f;
     }
 
     virtual EModuleType GetModuleType() const override { return EModuleType::Spawn; }
 
-    // 스폰 관련 헬퍼 함수 (FParticleEmitterInstance에서 사용될 수 있음)
-    float GetSpawnRate(float EmitterTime) const; // 현재 시간에 맞는 스폰율 반환
-    int32 GetBurstCount(float EmitterTime, float DeltaTime) const; // 이번 틱에 발생할 버스트 파티클 수 반환
+    /**
+   * 현재 이미터 시간(EmitterTime)를 기준으로
+   * 초당 파티클 생성률을 반환합니다. Rate 및 RateScale 분포 설정을 고려합니다.
+   */
+    float GetEffectiveSpawnRate(float EmitterTime) const;
+
+    /**
+      * 이번 델타 시간(DeltaTime) 동안, 현재 이미터 시간(EmitterTime)을 기준으로
+      * 시간상으로 발생해야 하는 모든 버스트의 총 파티클 수를 반환합니다.
+      */
+    int32 GetBurstAmountForThisTick(float EmitterTime, float DeltaTime) const;
+
+    /**
+     * (CalculateMaxActiveParticleCount 용도)
+     * BurstList에 정의된 모든 버스트의 총 파티클 수를 반환합니다.
+     * (루프에 따른 중첩은 고려하지 않는 단순 합계)
+     */
+    int32 GetTotalBurstAmountSimple() const;
 };

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleTypeDataMesh.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleModuleTypeDataMesh.cpp
@@ -1,24 +1,35 @@
 #include "ParticleModuleTypeDataMesh.h"
+#include "Engine/AssetManager.h"
 #include "ParticleEmitter.h"
+#include "Engine/Engine.h"
+#include "UObject/Casts.h"
+#include "Runtime/Windows/SubWindow/SubEngine.h"
+#include "Components/Mesh/StaticMeshRenderData.h"
+
 void UParticleModuleTypeDataMesh::Build(const FParticleEmitterBuildInfo& EmitterBuildInfo)
 {
-    Super::Build(EmitterBuildInfo); 
+    Super::Build(EmitterBuildInfo);
 
-    if ((EmitterBuildInfo.bIsEditorBuild || !this->Mesh) && !this->MeshAssetPath.IsEmpty())
+    if (!Mesh && !MeshAssetPath.IsEmpty())
     {
-       
-        // this->Mesh = LoadDummyMesh(this->MeshAssetPath); // 실제 메시 로딩 함수 호출
-                                                      // LoadObject<UStaticMesh>(nullptr, *this->MeshAssetPath); 와 유사
+        UE_LOG(ELogLevel::Warning, TEXT("UParticleModuleTypeDataMesh::Build (Runtime) - Mesh is null but MeshAssetPath ('%s') exists. Mesh should have been serialized."), *MeshAssetPath);
 
-        // if (this->Mesh)
-        // {
-        //     // UE_LOG(LogTemp, Log, TEXT("Successfully 'loaded' mesh: %s"), *this->Mesh->GetName());
-        // }
-        // else
-        // {
-        //     // UE_LOG(LogTemp, Warning, TEXT("Failed to 'load' mesh from path: %s"), *this->MeshAssetPath);
-        // }
     }
+
+    if ((EmitterBuildInfo.bIsEditorBuild || !Mesh) && !MeshAssetPath.IsEmpty())
+    {
+        Mesh = UAssetManager::Get().GetStaticMesh(MeshAssetPath);
+
+        if (Mesh)
+        {
+            UE_LOG(ELogLevel::Display, TEXT("Successfully 'loaded' mesh: %s"), *Mesh->GetName());
+        }
+        else
+        {
+            UE_LOG(ELogLevel::Warning, TEXT("Failed to 'load' mesh from path: %s"), *this->MeshAssetPath);
+        }
+    }
+
     // 런타임에는 이미 직렬화된 Mesh 포인터가 로드되어 있거나,
     // 여기서 로드된 Mesh 포인터를 사용합니다.
 }

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleSystem.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleSystem.cpp
@@ -1,5 +1,7 @@
 #include "ParticleSystem.h"
 #include "ParticleEmitter.h"
+#include "ParticleLODLevel.h"
+#include "ParticleModuleRequired.h"
 
 UParticleSystem::UParticleSystem()
     : Delay(0.0f)
@@ -18,4 +20,36 @@ void UParticleSystem::BuildEmitters()
             Emitter->Build(); // 각 이미터의 Build 함수 호출
         }
     }
+}
+
+void UParticleSystem::InitializeSystem()
+{
+    BuildEmitters();
+    UpdateComputedFlags();
+}
+
+void UParticleSystem::UpdateComputedFlags() // 이 함수는 private 멤버로 선언하는 것이 좋음
+{
+    bIsLooping_Computed = false; // 기본값으로 시작
+
+    for (const UParticleEmitter* Emitter : Emitters)
+    {
+        if (Emitter)
+        {
+            UParticleLODLevel* HighLOD = Emitter->GetHighestLODLevel(); // UParticleEmitter에 GetHighestLODLevel() 구현 필요
+            if (HighLOD && HighLOD->RequiredModule)
+            {
+                // UParticleModuleRequired에 EmitterLoops 멤버 필요
+                if (HighLOD->RequiredModule->EmitterLoops == 0) // 0이면 무한 루프로 간주
+                {
+                    bIsLooping_Computed = true;
+                    break; // 하나라도 무한 루프면 전체 시스템도 루핑
+                }
+            }
+        }
+    }
+}
+void UParticleSystem::PostLoad()
+{
+    InitializeSystem();
 }

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleSystem.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Engine/Classes/Particle/ParticleSystem.h
@@ -15,15 +15,18 @@ public:
     float Delay;
 
     bool bAutoActivate; // 컴포넌트에 의해 활성화될 때 자동으로 시작할지 여부
-
+    bool bIsLooping_Computed = false;
 public:
     UParticleSystem();
     virtual ~UParticleSystem() = default;
 
+    void InitializeSystem();
+    
+    void UpdateComputedFlags();
+
     // 시스템 내 모든 이미터 빌드
     void BuildEmitters();
 
-    // (선택적) 시스템 로드 후 또는 에디터에서 변경 시 호출될 수 있는 함수
-    // virtual void PostLoad() override;
-    // virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+
+    void PostLoad();
 };

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Windows/SubWindow/ParticleSystemSubEngine.cpp
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Windows/SubWindow/ParticleSystemSubEngine.cpp
@@ -5,7 +5,7 @@
 #include "UnrealClient.h"
 #include "Actors/Cube.h"
 #include "Animation/Skeleton.h"
-#include "Actors/Cube.h"
+#include "Particle/ParticleSystem.h"
 #include "Engine/AssetManager.h"
 #include "PropertyEditor/Sub/ParticleSystemViewerPanel.h"
 
@@ -127,6 +127,7 @@ void UParticleSystemSubEngine::Render()
         if (particlePanel) 
         {
             particlePanel->PrepareRender(ViewportClient); // 내부적으로 멤버 변수 RenderTargetRHI 설정
+
         }
         UnrealEditor->Render(EWindowType::WT_ParticleSubWindow);
         SubUI->EndFrame();
@@ -152,4 +153,12 @@ void UParticleSystemSubEngine::Release()
         delete SubRenderer;
         SubRenderer = nullptr;
     }
+}
+
+void UParticleSystemSubEngine::OpenParticleSystemForEditing(UParticleSystem* InParticleSystem)
+{
+    ParticleSystem = InParticleSystem;
+    ParticleSystemViewerPanel* particlePanel = reinterpret_cast<ParticleSystemViewerPanel*>(UnrealEditor->GetSubParticlePanel("SubParticleViewerPanel").get());
+    particlePanel->SetEditedParticleSystem(ParticleSystem);
+
 }

--- a/RandEngine/RandEngine/Engine/Source/Runtime/Windows/SubWindow/ParticleSystemSubEngine.h
+++ b/RandEngine/RandEngine/Engine/Source/Runtime/Windows/SubWindow/ParticleSystemSubEngine.h
@@ -2,6 +2,7 @@
 
 #include "SubEngine.h"
 class UStaticMeshComponent;
+class UParticleSystem;
 class UParticleSystemSubEngine : public USubEngine
 {
     DECLARE_CLASS(UParticleSystemSubEngine, USubEngine)
@@ -14,5 +15,7 @@ public:
     virtual void Input(float DeltaTime);
     virtual void Render();
     virtual void Release();
+    void OpenParticleSystemForEditing(UParticleSystem* InParticleSystem);
     UStaticMeshComponent* UnrealSphereComponent = nullptr;
+    UParticleSystem* ParticleSystem = nullptr;
 };

--- a/RandEngine/RandEngine/RandEngine.vcxproj
+++ b/RandEngine/RandEngine/RandEngine.vcxproj
@@ -208,6 +208,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\fmod\lib\$(Pl
   <ItemGroup>
     <ClCompile Include="Engine\Source\Contents\Actors\ARandCharacter.cpp" />
     <ClCompile Include="Engine\Source\Editor\PropertyEditor\Sub\ParticleSystemViewerPanel.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Core\Math\DistributionFloat.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\AnimationRuntime.cpp" />
     <ClCompile Include="Engine\Source\Editor\PropertyEditor\Sub\SkeletalDetailPanel.cpp" />
     <ClCompile Include="Engine\Source\Editor\PropertyEditor\Sub\ViewerControlPanel.cpp" />
@@ -528,6 +529,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\fmod\lib\$(Pl
     <ClInclude Include="Engine\Source\Developer\AnimationUtils\AnimationUtils.h" />
     <ClInclude Include="Engine\Source\Editor\PropertyEditor\Sub\AnimationTimelineCommon.h" />
     <ClInclude Include="Engine\Source\Editor\PropertyEditor\Sub\ParticleSystemViewerPanel.h" />
+    <ClInclude Include="Engine\Source\Runtime\Core\Math\DistributionFloat.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\AnimationRuntime.h" />
     <ClInclude Include="Engine\Source\Editor\PropertyEditor\Sub\SkeletalDetailPanel.h" />
     <ClInclude Include="Engine\Source\Editor\PropertyEditor\Sub\ViewerControlPanel.h" />


### PR DESCRIPTION
UParticleSystem, UParticleEmitter, UParticleLODLevel 클래스 간의 데이터 준비 및 정보 캐싱 플로우를 구현했습니다.

주요 변경 사항:
- UParticleSystem::InitializeSystem(): 모든 이미터의 Build() 호출 및 시스템 전체 플래그 업데이트 로직 추가.
- UParticleEmitter::Build():
    - UParticleLODLevel::CompileModules()를 호출하여 FParticleEmitterBuildInfo 준비.
    - UParticleModuleTypeDataBase::Build() 및 CacheModuleInfo() 호출.
    - 최종적으로 CacheEmitterModuleInfo()를 호출하여 런타임 정보 캐싱.
- UParticleEmitter::CacheEmitterModuleInfo():
    - TypeDataModule 및 일반 모듈들의 RequiredBytes/RequiredBytesPerInstance를 기반으로 ParticleSize, 모듈 오프셋 등 계산.
    - 계산된 결과를 _Cached 접미사가 붙은 멤버 변수에 저장하여 FParticleEmitterInstance에서 사용하도록 준비.
- UParticleLODLevel::CompileModules():
    - FParticleEmitterBuildInfo 구조체에 RequiredModule, SpawnModule, TypeDataModule 참조 및 EstimatedMaxActiveParticleCount 설정 로직 구현.
- UParticleLODLevel::CalculateMaxActiveParticleCount():
    - SpawnModule의 스폰율/버스트 및 LifetimeModule의 수명을 기반으로 최대 활성 파티클 수 추정 로직 개선. (아직 분포 값 처리는 단순화됨)
- UParticleModuleTypeDataMesh::Build():
    - 에디터 환경에서 MeshAssetPath를 사용하여 UStaticMesh 참조를 설정하는 기본 로직 추가 (실제 에셋 로딩 연동 필요).

다음 단계:
- 각 UParticleModule (Lifetime, Spawn, Color, Size 등)의 Spawn() 및 Update() 핵심 로직 구현.
- FParticleEmitterInstance의 InitParameters() 및 Tick() 함수 상세 구현 및 검증.

주의/불안 요소:
- FParticleEmitterInstance 초기화 시 UParticleEmitter의 _Cached 값들이 정확히 전달되고 사용되는지, 특히 메모리 레이아웃 및 오프셋 계산 부분에 대한 철저한 검증 필요.
- 각 모듈의 RequiredBytes/RequiredBytesPerInstance가 정확한 값을 반환하는지 확인 필요.
- 현재 CalculateMaxActiveParticleCount는 FDistributionFloat의 실제 값 대신 상수 또는 대표값을 사용하고 있어 추정치의 정확도가 낮을 수 있음.